### PR TITLE
fix(g2p update): errors in mappings now produce user-meaningful error…

### DIFF
--- a/g2p/exceptions.py
+++ b/g2p/exceptions.py
@@ -36,8 +36,11 @@ class InvalidNormalization(CommandLineError):
         ))
 
 class MalformedMapping(CommandLineError):
-    def __init__(self):
-        pass
+    def __init__(self, message=""):
+        if message:
+            self.message = "\n\n" + message
+        else:
+            self.message = ""
     
     def __str__(self):
         return self.render((
@@ -46,6 +49,7 @@ class MalformedMapping(CommandLineError):
             'You might be missing some keywords or \n'
             'Not all of the input and output pairs in your mapping have values for "in" and "out"\n'
             'Please refer to the documentation and fix your mapping.'
+            + self.message
         ))
 
 class MalformedLookup(CommandLineError):

--- a/g2p/mappings/__init__.py
+++ b/g2p/mappings/__init__.py
@@ -87,12 +87,12 @@ class Mapping():
                 abbreviations)
         # Handle user-supplied list
         if isinstance(mapping, list):
-            self.mapping = validate(mapping)
+            self.mapping = validate(mapping, path="user-supplied mapping")
         elif isinstance(mapping, str) and (mapping.endswith('yaml') or mapping.endswith('yml')):
             loaded_config = load_mapping_from_path(mapping)
             self.process_loaded_config(loaded_config)
         elif isinstance(mapping, str):
-            self.mapping = validate(load_from_file(mapping))
+            self.mapping = validate(load_from_file(mapping), path=mapping)
         else:
             if "in_lang" in self.kwargs and "out_lang" in self.kwargs:
                 loaded_config = find_mapping(

--- a/g2p/tempfile.py
+++ b/g2p/tempfile.py
@@ -1,0 +1,76 @@
+"""
+Wrapper to make tempfile.NamedTemporaryFile work as we need it to on Windows and *nix.
+Desired behaviour: with delete=True, we want to be able to write to the file, and open it again
+with a different file handle for reading. On Linux, closing the file deletes it right away,
+while on Windows, you cannot reopen the file unless you've closed it first.
+So this wrapper deletes the file on exit or object deletion instead of closing.
+"""
+
+import os
+from tempfile import NamedTemporaryFile, _TemporaryFileWrapper, template  # type: ignore
+
+from readalongs.log import LOGGER
+
+
+class _PortableNamedTemporaryFileWrapperSubclass(_TemporaryFileWrapper):
+    def __init__(self):
+        pass
+
+
+class _PortableNamedTemporaryFileWrapper:
+    def __init__(self, named_temporary_file):
+        self.named_temporary_file = named_temporary_file
+        self.name = named_temporary_file.name
+        # LOGGER.info("_PortableNamedTemporaryFileWrapper.name={}".format(self.name))
+
+    def __enter__(self):
+        self.named_temporary_file.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        result = self.named_temporary_file.__exit__(exc_type, exc_value, traceback)
+        self.cleanup()
+        return result
+
+    def __del__(self):
+        self.cleanup()
+
+    def __getattr__(self, name):
+        return self.named_temporary_file.__getattr__(name)
+
+    def close(self):
+        return self.named_temporary_file.close()
+
+    # def __iter__(self):
+    #    for line in self.named_temporary_file:
+    #        yield line
+
+    def cleanup(self):
+        self.close()
+        try:
+            os.unlink(self.named_temporary_file.name)
+        except FileNotFoundError:
+            pass  # cleaning up more than once is not an error
+
+
+def PortableNamedTemporaryFile(
+    mode="w+b", suffix="", prefix=template, dir=None, delete=True
+):
+    """
+    Wrap tempfile.NamedTemporaryFile() with a portable behaviour that works on Windows, Linux and Mac
+    See https://docs.python.org/3/library/tempfile.html for full documentation.
+    The difference is that if you specify delete=True, the temporary file will be deleted when the returned
+    object is destroyed rather than when the file is closed. On windows, it is not possible to reopen the
+    file while the original handle is still open, so this function makes temporary files work across OS's.
+    """
+    if not delete:
+        return NamedTemporaryFile(
+            mode=mode, suffix=suffix, prefix=prefix, delete=delete
+        )
+    else:
+        named_temporary_file = NamedTemporaryFile(
+            mode=mode, suffix=suffix, prefix=prefix, delete=False
+        )
+        return _PortableNamedTemporaryFileWrapper(
+            named_temporary_file=named_temporary_file
+        )

--- a/g2p/tests/run.py
+++ b/g2p/tests/run.py
@@ -21,6 +21,7 @@ from g2p.tests.test_fallback import FallbackTest
 from g2p.tests.test_api_resources import ResourceIntegrationTest
 from g2p.tests.test_studio import StudioTest
 from g2p.tests.test_doctor import DoctorTest
+from g2p.tests.test_temp_file import TestTempFile
 
 
 LOADER = TestLoader()
@@ -52,7 +53,7 @@ LANGS_TESTS = [
 
 INTEGRATION_TESTS = [
     LOADER.loadTestsFromTestCase(test) for test in [
-        CliTest, ResourceIntegrationTest, StudioTest, DoctorTest
+        CliTest, ResourceIntegrationTest, StudioTest, DoctorTest, TestTempFile,
     ]
 ]
 

--- a/g2p/tests/test_mappings.py
+++ b/g2p/tests/test_mappings.py
@@ -8,6 +8,8 @@ from contextlib import redirect_stderr
 from g2p.mappings import Mapping
 from g2p.transducer import Transducer
 from g2p.tests.public import __file__ as public_data
+from g2p import exceptions
+from g2p.tempfile import PortableNamedTemporaryFile
 import unicodedata as ud
 
 class MappingTest(TestCase):
@@ -184,6 +186,23 @@ class MappingTest(TestCase):
         mapping = Mapping(os.path.join(os.path.dirname(public_data), 'mappings', 'no_escape.csv'))
         transducer = Transducer(mapping)
         self.assertEqual(transducer('?').output_string, 'ʔ')
+
+    def test_invalid_rules_json(self):
+        rules = [{'in': 'a'}, {'out': 'c'}]
+        self.assertRaises(exceptions.MalformedMapping, Mapping, rules)
+
+    def test_invalid_rules_csv(self):
+        tf = PortableNamedTemporaryFile(prefix="test_invalid_rules_", mode="w", suffix=".csv")
+        tf.write("good-in,good-out\n\ngood-in-no-out\n")
+        tf.close()
+        self.assertRaises(exceptions.MalformedMapping, Mapping, tf.name)
+
+    def test_invalid_rules_filetype(self):
+        tf = PortableNamedTemporaryFile(prefix="test_invalid_rules_", mode="w", suffix=".foo")
+        tf.write("good-in,good-out\n\ngood-in-no-out\n")
+        tf.close()
+        self.assertRaises(TypeError, Mapping, tf.name)
+
 
 if __name__ == "__main__":
     main()

--- a/g2p/tests/test_temp_file.py
+++ b/g2p/tests/test_temp_file.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+"""
+Test PortableNamedTemporaryFile class
+"""
+
+import os
+import sys
+import unittest
+from tempfile import NamedTemporaryFile
+
+from g2p.log import LOGGER
+from g2p.tempfile import PortableNamedTemporaryFile
+
+
+class TestTempFile(unittest.TestCase):
+    def testBasicFile(self):
+        f = open("delme_test_temp_file", mode="w")
+        f.write("some text")
+        f.close()
+        os.unlink("delme_test_temp_file")
+
+    def testNTF(self):
+        tf = NamedTemporaryFile(prefix="testtempfile_testNTF_", delete=False, mode="w")
+        tf.write("Some text")
+        # LOGGER.debug("tf.name {}".format(tf.name))
+        tf.close()
+        readf = open(tf.name, mode="r")
+        text = readf.readline()
+        self.assertEqual(text, "Some text")
+        readf.close()
+        os.unlink(tf.name)
+
+    def testDeleteFalse(self):
+        tf = PortableNamedTemporaryFile(
+            prefix="testtempfile_testDeleteFalse_", delete=False, mode="w"
+        )
+        tf.write("Some text")
+        tf.close()
+        # LOGGER.info(tf.name)
+        readf = open(tf.name, mode="r")
+        text = readf.readline()
+        readf.close()
+        self.assertEqual(text, "Some text")
+        os.unlink(tf.name)
+
+    def testTypicalUsage(self):
+        tf = PortableNamedTemporaryFile(
+            prefix="testtempfile_testTypicalUsage_", delete=True, mode="w"
+        )
+        # LOGGER.info(tf.name)
+        tf.write("Some text")
+        tf.close()
+        # LOGGER.info(tf.name)
+        readf = open(tf.name, mode="r")
+        text = readf.readline()
+        readf.close()
+        self.assertEqual(text, "Some text")
+
+    def testUsingWith(self):
+        with PortableNamedTemporaryFile(
+            prefix="testtempfile_testUsingWith_", delete=True, mode="w"
+        ) as tf:
+            # LOGGER.info(tf.name)
+            tf.write("Some text")
+            tf.close()
+            # LOGGER.info(tf.name)
+            readf = open(tf.name, mode="r")
+            text = readf.readline()
+            readf.close()
+            self.assertEqual(text, "Some text")
+
+    def testSeek(self):
+        tf = PortableNamedTemporaryFile(
+            prefix="testtempfile_testSeek_", delete=True, mode="w+"
+        )
+        tf.write("Some text")
+        tf.seek(0)
+        text = tf.readline()
+        self.assertEqual(text, "Some text")
+        tf.close()
+        os.unlink(tf.named_temporary_file.name)
+
+
+if __name__ == "__main__":
+    LOGGER.setLevel("DEBUG")
+    unittest.main()


### PR DESCRIPTION
fix(g2p update): errors in mappings now produce user-meaningful error messages

This is accomplished by have exceptions.MalformedMapping take a message
argument that gets printed after the generic information.

also:
 - Mappings in .csv/.tsv format are now allowed to have blank lines, which are
   simply ignored.
 - When a line in a .csv/.tsv file has only one field, an error message
   explicitly says the "out" field is required, via exceptions.MalformedMapping.

Blank lines in .csv/.tsv files is what triggered the current commit: previously,
a blank line accidentally added to the file would cause an index error saying
entry[0] had an index out of range, which was not informative.
