### PR TITLE
chore: travis should run all tests, not just dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 
 # commands to run the testing suite. if any of these fail, travic lets us know
 script: 
-  - cd /home/travis/build/roedoejet/g2p && coverage run --source g2p run_tests.py dev
+  - cd /home/travis/build/roedoejet/g2p && coverage run --source g2p run_tests.py all
 
 # commands to run after the tests successfully complete
 after_success:


### PR DESCRIPTION
This PR is just to update the travis configuration to run all tests, not just `dev`. Right now, that makes no difference, but when tests are added they should automatically be included in the travis runs even if they are not added to a set that is part of dev.