### PR TITLE
fix(g2p doctor): --list-* options should print langs sorted

### DIFF
--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -163,7 +163,7 @@ def doctor(mapping, list_all, list_ipa):
             print(f"{m}: ", end="")
             print(
                 ("\n" + " " * len(m) + "  ").join(
-                    [x["in_lang"] for x in MAPPINGS_AVAILABLE if x["out_lang"] == m]
+                    sorted([x["in_lang"] for x in MAPPINGS_AVAILABLE if x["out_lang"] == m])
                 )
             )
             print("")


### PR DESCRIPTION
Tiny PR, I know, to make `g2p doctor --list-all` output languages in alphabetical order and thus make the output a lot more legible.