### PR TITLE
-norm to -equiv

### DIFF
--- a/g2p/mappings/langs/crj/config.yaml
+++ b/g2p/mappings/langs/crj/config.yaml
@@ -3,7 +3,7 @@
 mappings:
   - display_name: Northern East Cree Normalization
     in_lang: crj
-    out_lang: crj-norm
+    out_lang: crj-equiv
     type: mapping
     authors:
       - Delasie Torkornoo
@@ -12,7 +12,7 @@ mappings:
     rule_ordering: as-written
     <<: *shared
   - display_name: Southern East Cree to IPA
-    in_lang: crj-norm
+    in_lang: crj-equiv
     out_lang: crj-ipa
     type: mapping
     authors:

--- a/g2p/mappings/langs/crl/config.yaml
+++ b/g2p/mappings/langs/crl/config.yaml
@@ -3,7 +3,7 @@
 mappings:
   - display_name: Northern East Cree Normalization
     in_lang: crl
-    out_lang: crl-norm
+    out_lang: crl-equiv
     type: mapping
     authors:
       - Delasie Torkornoo
@@ -11,7 +11,7 @@ mappings:
     mapping: crl_norm.json
     <<: *shared
   - display_name: Northern East Cree to IPA
-    in_lang: crl-norm
+    in_lang: crl-equiv
     out_lang: crl-ipa
     type: mapping
     authors:

--- a/g2p/mappings/langs/crm/config.yaml
+++ b/g2p/mappings/langs/crm/config.yaml
@@ -3,7 +3,7 @@
 mappings:
   - display_name: Moose Cree Normalization
     in_lang: crm
-    out_lang: crm-norm
+    out_lang: crm-equiv
     type: mapping
     authors:
       - Delasie Torkornoo
@@ -12,7 +12,7 @@ mappings:
     mapping: crm_norm.json
     <<: *shared
   - display_name: Moose Cree to IPA
-    in_lang: crm-norm
+    in_lang: crm-equiv
     out_lang: crm-ipa
     type: mapping
     authors:

--- a/g2p/mappings/langs/csw/config.yaml
+++ b/g2p/mappings/langs/csw/config.yaml
@@ -3,7 +3,7 @@
 mappings:
   - display_name: Swampy Cree Normalization
     in_lang: csw
-    out_lang: csw-norm
+    out_lang: csw-equiv
     type: mapping
     authors:
       - Delasie Torkornoo
@@ -12,7 +12,7 @@ mappings:
     mapping: csw_norm.json
     <<: *shared
   - display_name: Swampy Cree to IPA
-    in_lang: csw-norm
+    in_lang: csw-equiv
     out_lang: csw-ipa
     type: mapping
     authors:

--- a/g2p/mappings/langs/generated/config.yaml
+++ b/g2p/mappings/langs/generated/config.yaml
@@ -117,7 +117,7 @@ mappings:
     escape_special: false
     in_lang: tce-ipa
     language_name: tce-ipa
-    mapping: tce-norm-ipa_to_eng-ipa.json
+    mapping: tce-equiv-ipa_to_eng-ipa.json
     norm_form: NFC
     out_lang: eng-ipa
     prevent_feeding: true
@@ -142,7 +142,7 @@ mappings:
     escape_special: false
     in_lang: tli-ipa
     language_name: Tlingit IPA
-    mapping: tli-norm-ipa_to_eng-ipa.json
+    mapping: tli-equiv-ipa_to_eng-ipa.json
     norm_form: NFC
     out_lang: eng-ipa
     prevent_feeding: false

--- a/g2p/mappings/langs/git/config.yaml
+++ b/g2p/mappings/langs/git/config.yaml
@@ -19,7 +19,7 @@ mappings:
     <<: *shared
   - display_name: Unicode Normalization
     in_lang: git
-    out_lang: git-norm
+    out_lang: git-equiv
     authors:
       - Aidan Pine
     mapping: norm.csv

--- a/g2p/mappings/langs/tce/config.yaml
+++ b/g2p/mappings/langs/tce/config.yaml
@@ -3,7 +3,7 @@
 mappings:
   - display_name: Southern Tutchone normalization
     in_lang: tce
-    out_lang: tce-norm
+    out_lang: tce-equiv
     authors:
       - Shankhalika Srikanth
     type: mapping
@@ -14,7 +14,7 @@ mappings:
     norm_form: NFC
     <<: *shared
   - display_name: Southern Tutchone to IPA
-    in_lang: tce-norm
+    in_lang: tce-equiv
     out_lang: tce-ipa
     authors:
       - Shankhalika Srikanth

--- a/g2p/mappings/langs/tli/config.yaml
+++ b/g2p/mappings/langs/tli/config.yaml
@@ -3,7 +3,7 @@
 mappings:
   - display_name: Tlingit normalization
     in_lang: tli
-    out_lang: tli-norm
+    out_lang: tli-equiv
     authors:
       - Shankhalika Srikanth
     type: mapping
@@ -14,7 +14,7 @@ mappings:
     norm_form: NFC
     <<: *shared
   - display_name: Tlingit to IPA
-    in_lang: tli-norm
+    in_lang: tli-equiv
     out_lang: tli-ipa
     authors:
       - Shankhalika Srikanth


### PR DESCRIPTION
Removing -norm from the `config.yaml` files so the user sees -equiv.