### PR TITLE
Dev.workflow: update the workflow to only publish from release branch

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -7,10 +7,6 @@ on:
     types: [created]
   push:
     branches: [ release ]
-    tags: 
-      - release
-      - build
-      - v*.*.*
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ The initial version of this package was developed by [Patrick Littell](https://g
 ## Install
 
 The best thing to do is install with pip `pip install g2p`. 
+This command will install the latest release published on [PyPI g2p releases](https://pypi.org/project/g2p/).
 
-Otherwise, clone the repo and pip install it locally.
+You can also clone the repo and pip install it locally:
 
 ```sh
 $ git clone https://github.com/roedoejet/g2p.git


### PR DESCRIPTION
Currently, the `pythonpublish.yml` workflow is triggered on
 - updating the `release` branch
 - pushing a tag called `release`
 - pushing a tag called `build`
 - pushing a tag matching `v*.*.*`

The workflow we want is to publish only when we update the `release` branch, which this PR does.

Also: link to PyPI repo from the README.