### PR TITLE
Automatically tag the repo on release

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -6,7 +6,7 @@ on:
   release:
     types: [created]
   push:
-    branches: [ dev.workflow_auto_tag ]
+    branches: [ release ]
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -26,19 +26,22 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
-        #twine upload dist/*
+        twine upload dist/*
     - name: Tag the repo
       run: |
         VERSION=`ls dist/g2p-*.tar.gz | sed -e 's/.*g2p-//' -e 's/.tar.gz.*//'`
-        echo git tag -a -m"Release version $VERSION" v$VERSION
-    #- name: trigger convertextract build
-    #  run: |
-    #    curl --location --request POST 'https://api.github.com/repos/roedoejet/convertextract/dispatches' \
-    #    --header 'Accept: application/vnd.github.everest-preview+json' \
-    #    --header 'Content-Type: application/json' \
-    #    --header 'Authorization: Bearer ${{ secrets.G2P_PAT }}' \
-    #    --header 'Content-Type: text/plain' \
-    #    --data-raw '{
-    #      "event_type": "g2p-published",
-    #      "client_payload": {}
-    #    }'
+        git config --global user.email hello@aidanpine.ca
+        git config --global user.name "Aidan Pine via GitHub Actions"
+        git tag -a -m"Release version $VERSION" v$VERSION
+        git push origin v$VERSION
+    - name: trigger convertextract build
+      run: |
+        curl --location --request POST 'https://api.github.com/repos/roedoejet/convertextract/dispatches' \
+        --header 'Accept: application/vnd.github.everest-preview+json' \
+        --header 'Content-Type: application/json' \
+        --header 'Authorization: Bearer ${{ secrets.G2P_PAT }}' \
+        --header 'Content-Type: text/plain' \
+        --data-raw '{
+          "event_type": "g2p-published",
+          "client_payload": {}
+        }'

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -27,13 +27,6 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
-    - name: Tag the repo
-      run: |
-        VERSION=`ls dist/g2p-*.tar.gz | sed -e 's/.*g2p-//' -e 's/.tar.gz.*//'`
-        git config --global user.email hello@aidanpine.ca
-        git config --global user.name "Aidan Pine via GitHub Actions"
-        git tag -a -m"Release version $VERSION" v$VERSION
-        git push origin v$VERSION
     - name: trigger convertextract build
       run: |
         curl --location --request POST 'https://api.github.com/repos/roedoejet/convertextract/dispatches' \
@@ -45,3 +38,10 @@ jobs:
           "event_type": "g2p-published",
           "client_payload": {}
         }'
+    - name: Tag the repo
+      run: |
+        VERSION=`ls dist/g2p-*.tar.gz | sed -e 's/.*g2p-//' -e 's/.tar.gz.*//'`
+        git config --global user.email hello@aidanpine.ca
+        git config --global user.name "Aidan Pine via GitHub Actions"
+        git tag -a -m"Release version $VERSION" v$VERSION
+        git push origin v$VERSION

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -3,8 +3,6 @@
 
 name: Upload Python Package
 on:
-  release:
-    types: [created]
   push:
     branches: [ release ]
 jobs:
@@ -38,10 +36,21 @@ jobs:
           "event_type": "g2p-published",
           "client_payload": {}
         }'
-    - name: Tag the repo
+    - name: Determine tag
+      id: determine_tag
       run: |
-        VERSION=`ls dist/g2p-*.tar.gz | sed -e 's/.*g2p-//' -e 's/.tar.gz.*//'`
-        git config --global user.email hello@aidanpine.ca
-        git config --global user.name "Aidan Pine via GitHub Actions"
-        git tag -a -m"Release version $VERSION" v$VERSION
-        git push origin v$VERSION
+        echo "::set-output name=TAG_VERSION::$(ls dist/g2p-*.tar.gz | sed -e 's/.*g2p-//' -e 's/.tar.gz.*//')"
+    - name: Bump version and push tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v5.5
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        custom_tag: ${{ steps.determine_tag.outputs.TAG_VERSION }}
+    - name: Create a GitHub release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.tag_version.outputs.new_tag }}
+        release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+        body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -6,7 +6,7 @@ on:
   release:
     types: [created]
   push:
-    branches: [ release ]
+    branches: [ dev.workflow_auto_tag ]
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -26,15 +26,19 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
-    - name: trigger convertextract build
+        #twine upload dist/*
+    - name: Tag the repo
       run: |
-        curl --location --request POST 'https://api.github.com/repos/roedoejet/convertextract/dispatches' \
-        --header 'Accept: application/vnd.github.everest-preview+json' \
-        --header 'Content-Type: application/json' \
-        --header 'Authorization: Bearer ${{ secrets.G2P_PAT }}' \
-        --header 'Content-Type: text/plain' \
-        --data-raw '{
-          "event_type": "g2p-published",
-          "client_payload": {}
-        }'
+        VERSION=`ls dist/g2p-*.tar.gz | sed -e 's/.*g2p-//' -e 's/.tar.gz.*//'`
+        echo git tag -a -m"Release version $VERSION" v$VERSION
+    #- name: trigger convertextract build
+    #  run: |
+    #    curl --location --request POST 'https://api.github.com/repos/roedoejet/convertextract/dispatches' \
+    #    --header 'Accept: application/vnd.github.everest-preview+json' \
+    #    --header 'Content-Type: application/json' \
+    #    --header 'Authorization: Bearer ${{ secrets.G2P_PAT }}' \
+    #    --header 'Content-Type: text/plain' \
+    #    --data-raw '{
+    #      "event_type": "g2p-published",
+    #      "client_payload": {}
+    #    }'


### PR DESCRIPTION
This PR changes the `pythonpublish.yml` workflow to tag the repo with the version just created automatically.
I tested this reasonably well, in this branch, with a version that echoes the tag command instead of running it. And I tested the tagged process in a different GitHub repo [Just-testing](https://github.com/joanise/just-testing) where I successfully tagged the repo at each commit I pushed in a similar workflow, so I'm fairly confident this will work. But, we'll only know for sure when we do the next g2p release...

Risk: not too much. I put the tag steps at the end, so if it fails, it won't prevent the rest of the workflow from happening. So I think the only risk is that the next release might or might not actually get tagged.

Caveat: it's a bit flaky getting `$VERSION` by parsing the filenames in the `dist/` directory, but we don't save the full version anywhere during the build, except in the wheel and tarball file names. Maybe we should also put the version somewhere client code can see e.g., possibly by changing `setup.py` so that `python setup.py sdist bdist_wheel` would update `_version.py` with the full version number including the build number?