### PR TITLE
fix(deps): make g2p compatible with Flask 2.0.1

### DIFF
--- a/g2p/api.py
+++ b/g2p/api.py
@@ -125,7 +125,7 @@ def update_docs():
     LOGGER.info('Updated API documentation')
 
 
-g2p_api = Blueprint('resources.g2p', __name__)
+g2p_api = Blueprint('resources-g2p', __name__)
 
 CORS(g2p_api)
 


### PR DESCRIPTION
Since 2.0.1, flask.blueprint.Blueprint does not accept a "." in the name
of the Blueprint.

FIXES: #111
