### PR TITLE
Dev.optimize test suites

### DIFF
--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -84,6 +84,8 @@ class CliTest(TestCase):
 
         # Disable this test: it's very slow (8s, just by itself) and does not assert
         # anything useful.
+        # Migrated to test_doctor_expensive.py so we can still run it, manually or via
+        # ./run.py all.
         # result = self.runner.invoke(doctor)
         # self.assertEqual(result.exit_code, 0)
         # self.assertGreaterEqual(len(result.stdout), 10000)

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -82,9 +82,11 @@ class CliTest(TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("vagon", result.stdout)
 
-        result = self.runner.invoke(doctor)
-        self.assertEqual(result.exit_code, 0)
-        self.assertGreaterEqual(len(result.stdout), 10000)
+        # Disable this test: it's very slow (8s, just by itself) and does not assert
+        # anything useful.
+        # result = self.runner.invoke(doctor)
+        # self.assertEqual(result.exit_code, 0)
+        # self.assertGreaterEqual(len(result.stdout), 10000)
 
         result = self.runner.invoke(doctor, "-m eng-arpabet")
         self.assertEqual(result.exit_code, 0)

--- a/g2p/tests/test_doctor.py
+++ b/g2p/tests/test_doctor.py
@@ -15,7 +15,10 @@ class DoctorTest(TestCase):
         self.assertIn("panphon", "".join(cm.output))
         self.assertGreaterEqual(len(cm.output), 2)
 
-    def test_ipa_known_segs_all(self):
+    # this test takes 8 seconds and doesn't do anything useful: it trivially increases
+    # code coverage but does not have enough assertions to catch a future code-breaking
+    # change.
+    def not_test_ipa_known_segs_all(self):
         with self.assertLogs(LOGGER, level='WARNING') as cm:
             check_ipa_known_segs()
         self.assertGreaterEqual(len(cm.output), 20)

--- a/g2p/tests/test_doctor.py
+++ b/g2p/tests/test_doctor.py
@@ -18,6 +18,8 @@ class DoctorTest(TestCase):
     # this test takes 8 seconds and doesn't do anything useful: it trivially increases
     # code coverage but does not have enough assertions to catch a future code-breaking
     # change.
+    # Migrated to test_doctor_expensive.py so we can still run it, manually or via
+    # ./run.py all.
     def not_test_ipa_known_segs_all(self):
         with self.assertLogs(LOGGER, level='WARNING') as cm:
             check_ipa_known_segs()

--- a/g2p/tests/test_doctor_expensive.py
+++ b/g2p/tests/test_doctor_expensive.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+from unittest import TestCase, main
+
+from g2p.app import APP
+from g2p.cli import doctor
+from g2p.log import LOGGER
+from g2p.mappings.langs.utils import check_ipa_known_segs
+
+
+class ExpensiveDoctorTest(TestCase):
+    # We segragate the expensive tests for g2p doctor in this suite which is not included
+    # in dev, so that it doesn't slow down our Travis CI tests, but can still be run by
+    # hand when desired.
+    # These tests are not very good because they don't assert enough to make sure doctor
+    # actually works, but they still exercise the code.
+    #
+    # This test suite is deliberately left out of run.py: it will only get run if you run
+    # ./run.py all, or ./test_doctor_expensive.py.
+
+    # Migrated here from test_cli.py
+    def test_doctor_cli(self):
+        # TODO: assert something more useful here...
+        # This test simulates calling "g2p doctor" on the command line with no arguments,
+        # which runs doctor on all mappings.
+        runner = APP.test_cli_runner()
+        result = runner.invoke(doctor)
+        self.assertEqual(result.exit_code, 0)
+        self.assertGreaterEqual(len(result.stdout), 10000)
+
+    # Migrated here from test_doctor.py
+    def test_ipa_known_segs_all(self):
+        # This test simulates the innards of having called "g2p doctor" on the command
+        # line with no arguments, again running the innards of doctor on all mappings.
+        with self.assertLogs(LOGGER, level="WARNING") as cm:
+            check_ipa_known_segs()
+        self.assertGreaterEqual(len(cm.output), 20)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
For a small drop in code coverage, this PR makes the unit testing suite 20-25s faster.

There were two calls to `g2p doctor` -- one via the CLI, one via the underlying function -- which cost about 25 s together, but did not assert anything useful, so that even a breaking change would probably not have been caught.

So I'm removing these two calls from the test suite: we'll all be happy seeing them run faster, both interactively and in CI.