### PR TITLE
Dev.no gpl: remove GPL dependencies and prevent future ones.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,15 @@ before_install:
 install:
   # Install Python dependencies
   - pip3 install -r /home/travis/build/roedoejet/g2p/requirements.txt
+  # Install g2p
+  - cd /home/travis/build/roedoejet/g2p && pip3 install -e .
+  # Legal check: make sure we don't introduce GPL dependencies
+  - pip3 install pip-licenses
+  - if pip-licenses | grep -v 'Artistic License,' | grep -v LGPL | grep GNU; then echo 'Please avoid introducing *GPL dependencies'; false; fi
   # Install testing requirements
   - pip3 install coverage
   - pip3 install coveralls
   - pip3 install gunicorn
-  # Install g2p
-  - cd /home/travis/build/roedoejet/g2p && pip3 install -e .
 
 before_script:
   - gunicorn --worker-class eventlet -w 1 g2p.app:APP --no-sendfile --bind 0.0.0.0:5000 --daemon

--- a/g2p/mappings/create_fallback_mapping.py
+++ b/g2p/mappings/create_fallback_mapping.py
@@ -1,6 +1,6 @@
 import os
 
-from unidecode import unidecode
+from text_unidecode import unidecode
 
 from g2p import make_g2p
 from g2p.log import LOGGER

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pyyaml
 regex
 requests
 tqdm
-unidecode
+text_unidecode


### PR DESCRIPTION
Using libraries licensed under the GPL runs of risk of having to consider the whole project GPL. Legal opinions vary on this, but I prefer to play it safe and just never use any GPL-licensed libraries in our code.

This PR does two things:
 - Use `text_unidecode` instead of `unidecode`, since the latter is GPL whereas the former is also available under the Artistic License.
 - Add a check in our Travis recipe so that a future change that introduces new GPL dependencies will fail to build.