### PR TITLE
chore: bump Flask-RESTful to >=0.3.9, for compatibility with Flask>=2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flask-cors
 Flask>=2.0.0
 flask_socketio==4.3.2
 flask-talisman
-flask-restful
+flask-restful>=0.3.9
 gunicorn
 networkx
 panphon


### PR DESCRIPTION
g2p was failing to run for me on Windows, and it turned out it was because I still had `flask-restful==0.3.8` installed. Our `requirements.txt` did not specify a version, so `pip install` failed to update it when it should have.

Ref: https://github.com/flask-restful/flask-restful/blob/master/CHANGES.md 