### PR TITLE
Make g2p generate-mapping accept non-standard mapping names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/roedoejet/g2p/badge.svg?branch=master)](https://coveralls.io/github/roedoejet/g2p?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/g2p/badge/?version=latest)](https://g2p.readthedocs.io/en/latest/?badge=latest)
-[![Build Status](https://travis-ci.com/roedoejet/g2p.svg?branch=master)](https://travis-ci.com/roedoejet/g2p)
+[![Build Status](https://travis-ci.com/roedoejet/g2p.svg?branch=master)](https://travis-ci.com/github/roedoejet/g2p)
 [![PyPI package](https://img.shields.io/pypi/v/g2p.svg)](https://pypi.org/project/g2p/)
 [![license](https://img.shields.io/badge/Licence-MIT-green)](LICENSE)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/roedoejet/g2p)

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -1,29 +1,29 @@
+import codecs
 import os
+import pprint
+import re
+from collections import OrderedDict
+
 import click
 import yaml
-import re
-import codecs
-import pprint
 from flask.cli import FlaskGroup
-from collections import OrderedDict
-from networkx import draw, has_path
-
-from g2p.exceptions import MappingMissing
-from g2p.transducer import CompositeTransducer, Transducer
-from g2p.mappings.create_fallback_mapping import (
-    align_to_dummy_fallback,
-    DUMMY_INVENTORY,
-)
-from g2p.mappings.langs import cache_langs, LANGS_NETWORK, MAPPINGS_AVAILABLE
-from g2p.mappings.langs.utils import check_ipa_known_segs
-from g2p.mappings.create_ipa_mapping import create_mapping
-from g2p.mappings.utils import is_ipa, is_xsampa, normalize
-from g2p.mappings import Mapping
-from g2p._version import VERSION
-from g2p.app import APP, SOCKETIO, network_to_echart
-from g2p.api import update_docs
-from g2p.log import LOGGER
 from g2p import make_g2p
+from g2p._version import VERSION
+from g2p.api import update_docs
+from g2p.app import APP, SOCKETIO, network_to_echart
+from g2p.exceptions import MappingMissing
+from g2p.log import LOGGER
+from g2p.mappings import Mapping
+from g2p.mappings.create_fallback_mapping import (
+    DUMMY_INVENTORY,
+    align_to_dummy_fallback,
+)
+from g2p.mappings.create_ipa_mapping import create_mapping
+from g2p.mappings.langs import LANGS_NETWORK, MAPPINGS_AVAILABLE, cache_langs
+from g2p.mappings.langs.utils import check_ipa_known_segs
+from g2p.mappings.utils import is_ipa, is_xsampa, normalize
+from g2p.transducer import CompositeTransducer, Transducer
+from networkx import draw, has_path
 
 PRINTER = pprint.PrettyPrinter(indent=4)
 
@@ -61,12 +61,10 @@ def cli():
     "out_lang",
     required=False,
     default=None,
-    #type=click.Choice([x for x in LANGS_NETWORK.nodes if is_ipa(x)]),
     type=str,
 )
 @click.argument(
     "in_lang",
-    #type=click.Choice([x for x in LANGS_NETWORK.nodes if not is_ipa(x) and not is_xsampa(x)]),
     type=str,
 )
 @cli.command(
@@ -96,7 +94,9 @@ def generate_mapping(in_lang, out_lang, dummy, ipa, list_dummy, out_dir):
         http://g2p-studio.herokuapp.com/api/v1/langs .
     """
 
-    in_lang_choices = [x for x in LANGS_NETWORK.nodes if not is_ipa(x) and not is_xsampa(x)]
+    in_lang_choices = [
+        x for x in LANGS_NETWORK.nodes if not is_ipa(x) and not is_xsampa(x)
+    ]
     if in_lang not in in_lang_choices:
         raise click.BadParameter(
             f'Invalid value for IN_LANG: "{in_lang}".\n'
@@ -115,7 +115,9 @@ def generate_mapping(in_lang, out_lang, dummy, ipa, list_dummy, out_dir):
         )
 
     if not ipa and not dummy and not list_dummy:
-        click.echo("Nothing to do! Please specify at least one of --ipa, --dummy or --list-dummy.")
+        click.echo(
+            "Nothing to do! Please specify at least one of --ipa, --dummy or --list-dummy."
+        )
 
     if out_dir and (
         os.path.exists(os.path.join(out_dir, "config.yaml"))
@@ -136,7 +138,6 @@ def generate_mapping(in_lang, out_lang, dummy, ipa, list_dummy, out_dir):
             raise click.BadParameter(f'Cannot find IPA mapping for "{in_lang}": {e}')
 
     if ipa:
-        #print(f"in_lang={in_lang} out_lang={out_lang}")
         check_ipa_known_segs([f"{in_lang}-ipa"])
         eng_ipa = Mapping(in_lang="eng-ipa", out_lang="eng-arpabet")
         click.echo(f"Writing English IPA mapping for {out_lang} to file")

--- a/g2p/exceptions.py
+++ b/g2p/exceptions.py
@@ -19,8 +19,8 @@ class MappingMissing(CommandLineError):
     def __str__(self):
         return self.render((
             '\n'
-            'There is no mapping between the languages "%(in_lang)s" and "%(out_lang)s", please\n'
-            'make sure you spelled the name correctly or go to\n'
+            'There is no mapping between the languages "%(in_lang)s" and "%(out_lang)s", \n'
+            'please make sure you spelled the name correctly or go to\n'
             'https://g2p-studio.herokuapp.com/api/v1/langs for a list of mappings'
         ))
 

--- a/g2p/exceptions.py
+++ b/g2p/exceptions.py
@@ -1,6 +1,6 @@
-'''
+"""
 All custom Exceptions
-'''
+"""
 
 # traceback from exceptions that inherit from this class are suppressed
 class CommandLineError(Exception):
@@ -8,64 +8,82 @@ class CommandLineError(Exception):
     errors occur on the command line to provide a useful command line
     interface.
     """
+
     def render(self, msg):
         return msg % vars(self)
 
+
 class MappingMissing(CommandLineError):
     def __init__(self, in_lang, out_lang):
+        super().__init__(self)
         self.in_lang = in_lang
         self.out_lang = out_lang
-    
+
     def __str__(self):
-        return self.render((
-            '\n'
-            'There is no mapping between the languages "%(in_lang)s" and "%(out_lang)s", \n'
-            'please make sure you spelled the name correctly or go to\n'
-            'https://g2p-studio.herokuapp.com/api/v1/langs for a list of mappings'
-        ))
+        return self.render(
+            (
+                "\n"
+                'There is no mapping between the languages "%(in_lang)s" and "%(out_lang)s", \n'
+                "please make sure you spelled the name correctly or go to\n"
+                "https://g2p-studio.herokuapp.com/api/v1/langs for a list of mappings"
+            )
+        )
+
 
 class InvalidNormalization(CommandLineError):
     def __init__(self, norm):
+        super().__init__(self)
         self.norm = norm
-    
+
     def __str__(self):
-        return self.render((
-            '\n'
-            'You provided an invalid argument "%(norm)s" to normalize with. \n'
-            'Please use "none" or "NFC", "NFKC", "NFD", or "NFKD"\n'
-        ))
+        return self.render(
+            (
+                "\n"
+                'You provided an invalid argument "%(norm)s" to normalize with. \n'
+                'Please use "none" or "NFC", "NFKC", "NFD", or "NFKD"\n'
+            )
+        )
+
 
 class MalformedMapping(CommandLineError):
     def __init__(self, message=""):
+        super().__init__(self)
         if message:
             self.message = "\n\n" + message
         else:
             self.message = ""
-    
+
     def __str__(self):
-        return self.render((
-            '\n'
-            'There is something wrong with your mapping. \n'
-            'You might be missing some keywords or \n'
-            'Not all of the input and output pairs in your mapping have values for "in" and "out"\n'
-            'Please refer to the documentation and fix your mapping.'
-            + self.message
-        ))
+        return self.render(
+            (
+                "\n"
+                "There is something wrong with your mapping. \n"
+                "You might be missing some keywords or \n"
+                'Not all of the input and output pairs in your mapping have values for "in" and "out"\n'
+                "Please refer to the documentation and fix your mapping." + self.message
+            )
+        )
+
 
 class MalformedLookup(CommandLineError):
     def __init__(self):
-        pass
-    
+        super().__init__(self)
+
     def __str__(self):
-        return self.render((
-            '\n'
-            'In order to use a default lookup table, you need to initialize \n'
-            'the Mapping class with a dictionary containing two keys: "lang" and "table". \n'
-            'Please try again.'
-        ))
+        return self.render(
+            (
+                "\n"
+                "In order to use a default lookup table, you need to initialize \n"
+                'the Mapping class with a dictionary containing two keys: "lang" and "table". \n'
+                "Please try again."
+            )
+        )
+
 
 class IncorrectFileType(CommandLineError):
     def __init__(self, msg):
+        super().__init__(self)
         self.msg = msg
+
     def __str__(self):
         return self.render(self.msg)

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
 
-from unittest import main, TestCase
-import os
 import csv
+import os
 import re
 from glob import glob
+from unittest import TestCase, main
 
 from g2p.app import APP
+from g2p.cli import convert, doctor, generate_mapping, scan, update
 from g2p.log import LOGGER
-from g2p.cli import convert, update, doctor, scan, generate_mapping
 from g2p.tests.public.data import __file__ as data_dir
 
 
 class CliTest(TestCase):
+    """Test suite for the g2p Command Line Interface"""
+
     def setUp(self):
         self.runner = APP.test_cli_runner()
         self.data_dir = os.path.dirname(data_dir)
@@ -40,7 +42,9 @@ class CliTest(TestCase):
         self.assertEqual(result.exit_code, 0)
 
     def test_convert(self):
-        LOGGER.info(f"Running {len(self.langs_to_test)} g2p convert test cases found in public/data")
+        LOGGER.info(
+            f"Running {len(self.langs_to_test)} g2p convert test cases found in public/data"
+        )
         error_count = 0
         for tok_option in [["--tok", "--check"], ["--no-tok"]]:
             for test in self.langs_to_test:
@@ -108,7 +112,9 @@ class CliTest(TestCase):
 
     def not_test_scan_fra(self):
         # TODO: fix fra g2p so fra_panagrams.txt passes
-        result = self.runner.invoke(scan, ["fra", os.path.join(self.data_dir, "fra_panagrams.txt")])
+        result = self.runner.invoke(
+            scan, ["fra", os.path.join(self.data_dir, "fra_panagrams.txt")]
+        )
         self.assertEqual(result.exit_code, 0)
         self.assertLogs(level="WARNING")
         diacritics = "àâéèêëîïôùûüç"
@@ -120,7 +126,9 @@ class CliTest(TestCase):
 
     def test_scan_fra_simple(self):
         # For now, unit test g2p scan using a simpler piece of French
-        result = self.runner.invoke(scan, ["fra", os.path.join(self.data_dir, "fra_simple.txt")])
+        result = self.runner.invoke(
+            scan, ["fra", os.path.join(self.data_dir, "fra_simple.txt")],
+        )
         self.assertEqual(result.exit_code, 0)
         self.assertLogs(level="WARNING")
         diacritics = "àâéèêëîïôùûüç"
@@ -129,22 +137,24 @@ class CliTest(TestCase):
         unmapped_chars = ":,"
         for c in unmapped_chars:
             self.assertIn(c, result.stdout)
-    
+
     def test_scan_str_case(self):
-        result = self.runner.invoke(scan, ["str", os.path.join(self.data_dir, "str_un_human_rights.txt")])
-        returned_set = re.search('{(.*)}', result.stdout).group(1)
+        result = self.runner.invoke(
+            scan, ["str", os.path.join(self.data_dir, "str_un_human_rights.txt")],
+        )
+        returned_set = re.search("{(.*)}", result.stdout).group(1)
         self.assertEqual(result.exit_code, 0)
-        self.assertLogs(level='WARNING')
-        unmapped_upper = 'FGR'
+        self.assertLogs(level="WARNING")
+        unmapped_upper = "FGR"
         for u in unmapped_upper:
             self.assertIn(u, returned_set)
-        unmapped_lower = 'abcdefghijklqrtwxyz'
+        unmapped_lower = "abcdefghijklqrtwxyz"
         for low in unmapped_lower:
             self.assertIn(low, returned_set)
-        mapped_upper = 'ABCDEHIJKLMNOPQSTUVWXYZ'
+        mapped_upper = "ABCDEHIJKLMNOPQSTUVWXYZ"
         for u in mapped_upper:
             self.assertNotIn(u, returned_set)
-        mapped_lower = 's'
+        mapped_lower = "s"
         self.assertNotIn(mapped_lower, returned_set)
 
     def test_convert_option_e(self):


### PR DESCRIPTION
Add optional OUT_LANG to "g2p generate-mapping" so that one can use it even with languages where the mapping goes through an equiv step.