### PR TITLE
Detect if g2p update needs to be run as part of the Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_script:
 # commands to run the testing suite. if any of these fail, travis lets us know
 script: 
   - cd /home/travis/build/roedoejet/g2p && coverage run --source g2p run_tests.py dev
+  - if git status | grep -E 'static.*json|mapping.*pkl'; then echo 'g2p databases out of date, please run "g2p update" and commit the results.'; false; else echo OK; fi
 
 # commands to run after the tests successfully complete
 after_success:
   - coveralls
-  - if git status | grep -E 'static.*json|mapping.*pkl'; then echo 'g2p databases out of date, please run "g2p update" and commit the results.'; false; else echo OK; fi


### PR DESCRIPTION
The unit tests run `g2p update`, among many things, so if the g2p databases were not already up to date, `git status` will report one or more of the .json or .pkl files that constitute our g2p database. In that case, make the CI build fail, so we catch this common error right away.