### PR TITLE
fix(doctor): oops, that last PR broken "g2p doctor" with no argument

### DIFF
--- a/g2p/mappings/langs/utils.py
+++ b/g2p/mappings/langs/utils.py
@@ -27,12 +27,12 @@ def getPanphonDistanceSingleton():
     return _PANPHON_DISTANCE_SINGLETON
 
 
-def check_ipa_known_segs(mappings_to_check=None) -> bool:
+def check_ipa_known_segs(mappings_to_check=False) -> bool:
     """Check the given mappings, or all IPA mappings, for invalid IPA in the "out" fields
 
     Returns True iff not errors were found.
     """
-    if mappings_to_check is None:
+    if not mappings_to_check:
         mappings_to_check = [x["out_lang"] for x in MAPPINGS_AVAILABLE]
     found_error = False
     for mapping in [


### PR DESCRIPTION
Doh! I should have tested my patch better. As the code now stands, `g2p doctor` does nothing. Revert my changes that broke doctor so that `g2p doctor` runs doctor against all -ipa mappings, as it used it.

Because `g2p doctor` is expensive to run, I previously disabled the unit test that runs it, but I guess that decision came back to byte me today.