### PR TITLE
refactor: make_g2p should raise more meaningful exceptions on caller errors

### DIFF
--- a/g2p/exceptions.py
+++ b/g2p/exceptions.py
@@ -30,6 +30,23 @@ class MappingMissing(CommandLineError):
         )
 
 
+class NoPath(CommandLineError):
+    def __init__(self, in_lang, out_lang):
+        super().__init__(self)
+        self.in_lang = in_lang
+        self.out_lang = out_lang
+
+    def __str__(self):
+        return self.render(
+            (
+                "\n"
+                'There is no g2p path between the languages "%(in_lang)s" and "%(out_lang)s", \n'
+                "please make sure you spelled the name correctly or go to\n"
+                "https://g2p-studio.herokuapp.com/api/v1/langs for a list of mappings"
+            )
+        )
+
+
 class InvalidNormalization(CommandLineError):
     def __init__(self, norm):
         super().__init__(self)
@@ -87,3 +104,12 @@ class IncorrectFileType(CommandLineError):
 
     def __str__(self):
         return self.render(self.msg)
+
+
+class InvalidLanguageCode(CommandLineError):
+    def __init__(self, lang):
+        super().__init__(self)
+        self.lang = lang
+
+    def __str__(self):
+        return self.render('No language called: "%(lang)s".')

--- a/g2p/tests/test_network.py
+++ b/g2p/tests/test_network.py
@@ -1,41 +1,38 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
-from unittest import main, TestCase
-import os
+from unittest import TestCase, main
 
-from networkx.exception import NetworkXNoPath
-
-from g2p.mappings import Mapping
-from g2p.transducer import CompositeTransducer, Transducer
 from g2p import make_g2p
+from g2p.exceptions import InvalidLanguageCode, NoPath
+from g2p.transducer import CompositeTransducer, Transducer
+
 
 class NetworkTest(TestCase):
-    ''' Basic Test for available networks
-    '''
+    """Basic Test for available networks"""
 
     def setUp(self):
         pass
 
     def test_not_found(self):
-        with self.assertRaises(FileNotFoundError):
-            make_g2p('foo', 'eng-ipa')
-        with self.assertRaises(FileNotFoundError):
-            make_g2p('git', 'bar')
+        with self.assertRaises(InvalidLanguageCode):
+            make_g2p("foo", "eng-ipa")
+        with self.assertRaises(InvalidLanguageCode):
+            make_g2p("git", "bar")
 
     def test_no_path(self):
-        with self.assertRaises(NetworkXNoPath):
-            make_g2p('hei', 'git')
+        with self.assertRaises(NoPath):
+            make_g2p("hei", "git")
 
     def test_valid_composite(self):
-        transducer = make_g2p('atj', 'eng-ipa')
+        transducer = make_g2p("atj", "eng-ipa")
         self.assertTrue(isinstance(transducer, CompositeTransducer))
-        self.assertEqual('niɡiɡw', transducer('nikikw').output_string)
+        self.assertEqual("niɡiɡw", transducer("nikikw").output_string)
 
     def test_valid_transducer(self):
-        transducer = make_g2p('atj', 'atj-ipa')
+        transducer = make_g2p("atj", "atj-ipa")
         self.assertTrue(isinstance(transducer, Transducer))
-        self.assertEqual('niɡiɡw', transducer('nikikw').output_string)
+        self.assertEqual("niɡiɡw", transducer("nikikw").output_string)
+
 
 if __name__ == "__main__":
     main()

--- a/run_studio.py
+++ b/run_studio.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from g2p.app import APP, SOCKETIO
 
 SOCKETIO.run(APP, host='0.0.0.0', port=5000, debug=True)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,9 @@
-from g2p.tests.run import run_tests
+#!/usr/bin/env python3
+
 import sys
 import unittest
+
+from g2p.tests.run import run_tests
 
 try:
     result = run_tests(sys.argv[1])


### PR DESCRIPTION
Change the exceptions raised by `make_g2p()` to NoPath and InvalidLanguageCode instead of NetworkXNoPath and FileNotFoundError.

Rationale:
 - the two exceptions are part of the g2p module and can be imported like `from g2p import make_g2p, NoPath, InvalidLanguageCode`
 - they're more intuitive (I think)
 - and I added documentation on `make_g2p()` with the `Raises:` field so these exceptions are documented as part of the API.