### PR TITLE
NFC as default for from/to gen'd mappings; NFD testing for g2p scan

### DIFF
--- a/g2p/mappings/create_ipa_mapping.py
+++ b/g2p/mappings/create_ipa_mapping.py
@@ -129,6 +129,7 @@ def create_multi_mapping(
         "rule_ordering": "apply-longest-first",
         "mapping": mapping,
         "prevent_feeding": True,
+        "norm_form": "NFC",
         "display_name": (
             long_ipa_names(map_1_names) + " to " + long_ipa_names(map_2_names)
         ),

--- a/g2p/tests/public/data/fra_panagrams_NFD.txt
+++ b/g2p/tests/public/data/fra_panagrams_NFD.txt
@@ -1,0 +1,4 @@
+https://fr.wikipedia.org/wiki/Pangramme
+
+Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.
+Dès Noël, où un zéphyr haï me vêt de glaçons würmiens, je dîne d’exquis rôtis de bœuf au kir, à l’aÿ d’âge mûr, &cætera. (contient les 42 caractères de la langue française) (Gilles Esposito-Farèse)

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -110,17 +110,19 @@ class CliTest(TestCase):
         self.assertIn("eng-ipa:", result.stdout)
 
     def test_scan_fra(self):
-        result = self.runner.invoke(
-            scan, ["fra", os.path.join(self.data_dir, "fra_panagrams.txt")]
-        )
-        self.assertEqual(result.exit_code, 0)
-        self.assertLogs(level="WARNING")
-        diacritics = "àâéèêëîïôùûüç"
-        for d in diacritics:
-            self.assertNotIn(d, result.stdout)
-        unmapped_chars = ":/,'-()2"
-        for c in unmapped_chars:
-            self.assertIn(c, result.stdout)
+        """Test g2p scan with all French characters, in NFC and NFD"""
+        for paragram_file in ["fra_panagrams.txt", "fra_panagrams_NFD.txt"]:
+            result = self.runner.invoke(
+                scan, ["fra", os.path.join(self.data_dir, paragram_file)]
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertLogs(level="WARNING")
+            diacritics = "àâéèêëîïôùûüç"
+            for d in diacritics:
+                self.assertNotIn(d, result.stdout)
+            unmapped_chars = ":/,'-()2"
+            for c in unmapped_chars:
+                self.assertIn(c, result.stdout)
 
     def test_scan_fra_simple(self):
         # For now, unit test g2p scan using a simpler piece of French


### PR DESCRIPTION
Quick PR:
 - make NFC the default for new generated mappings - this does not fix the larger issue (#147), it only applies NFC to new mappings generated in the from/to mode.
 - expanding the unit test for `g2p scan` to cover both NFC and NFD - that's stuff I prepared months ago but forgot about. I just noticed it this morning cleaning up old sandboxes.