### PR TITLE
Dockerfile optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -7,16 +7,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y apt-transport-https
 RUN apt-get install -y libffi-dev openssl libssl-dev python3 python3-pip python3-dev build-essential nano git
 
-RUN mkdir /g2p
-RUN mkdir /g2p/g2p
-COPY g2p /g2p/g2p
+# Get g2p-specific dependencies that can also often be cached
+RUN mkdir -p /g2p/g2p
 COPY requirements /g2p/requirements
 COPY requirements.txt /g2p
 COPY setup.py /g2p
-COPY README.md /g2p
+RUN MAKEFLAGS="-j$(nproc)" pip3 install -r /g2p/requirements.txt
 
-# Get g2p-specific dependencies
-RUN pip3 install -r /g2p/requirements.txt
+# Install g2p itself, last
+COPY g2p /g2p/g2p
+COPY README.md /g2p
+COPY Dockerfile /g2p
 RUN pip3 install -e /g2p
 
 # Comment this out if you just want to install g2p in the container without running the studio.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,3 +17,4 @@ regex
 requests
 tqdm
 text_unidecode
+werkzeug==2.0.3


### PR DESCRIPTION
Bump the OS to the current stable, bullseye
Optimize building the docker image
Lock werkzeug to 2.0.3, since our other dependency versions are not compatible with the latest, 2.1.0