### PR TITLE
Dev.computel fixes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,9 +6,11 @@
 Welcome to the G2P documentation!
 ==========================================
 
-.. note:: G2P is UNDER CONSTRUCTION and should not be expected to be fully documented or even work as expected! Check back soon for more information.
+G2P is a tool for doing rule-based conversions for text.
 
-G2P is a tool for visualizing and interacting with computational linguistic models.
+This website has the technical documentation for G2P, but we've also written a `7-part blog series <https://blog.mothertongues.org/g2p-background/>`__ if you want a more thorough introduction to why G2P exists and what you can use it for.
+
+
 
 .. toctree::
    :maxdepth: 2

--- a/docs/start.rst
+++ b/docs/start.rst
@@ -11,6 +11,8 @@ What is G2P?
 
 The initial version of this package was developed by `Patrick Littell <https://github.com/littell>`__ and was developed in order to allow for g2p from community orthographies to IPA and back again in `ReadAlong-Studio <https://github.com/dhdaines/ReadAlong-Studio>`__. We decided to then pull out the g2p mechanism from `Convertextract <https://github.com/roedoejet/convertextract>`__ which allows transducer relations to be declared in CSV files, and turn it into its own library - here it is!
 
+This website has the technical documentation for G2P, but we've also written a `7-part blog series <https://blog.mothertongues.org/g2p-background/>`__ if you want a more thorough introduction to why G2P exists and what you can use it for.
+
 
 
 

--- a/g2p/__init__.py
+++ b/g2p/__init__.py
@@ -53,6 +53,10 @@ def make_g2p(in_lang: str, out_lang: str, tok_lang=None):
         LOGGER.error(f"No lang called '{out_lang}'. Please try again.")
         raise InvalidLanguageCode(out_lang)
 
+    if in_lang == out_lang:
+        LOGGER.error(f"Sorry, you can't transduce between the same language. Please select a different output language code.")
+        raise NoPath(in_lang, out_lang)
+
     # Try to find the shortest path between the nodes
     try:
         path = shortest_path(LANGS_NETWORK, in_lang, out_lang)

--- a/g2p/tests/test_api_resources.py
+++ b/g2p/tests/test_api_resources.py
@@ -88,6 +88,7 @@ class ResourceIntegrationTest(TestCase):
         minimal_params = {'in-lang': 'dan', 'out-lang': 'eng-arpabet',
                   'text': "hej", 'debugger': False, 'index': False}
         bad_params = {'in-lang': 'dan', 'out-lang': 'moh', 'text': "hej"}
+        same_params = {'in-lang': 'dan', 'out-lang': 'dan', 'text': "hej"}
         missing_params = {'in-lang': 'not-here',
                           'out-lang': 'eng-arpabet', 'text': "hej"}
         self.maxDiff = None
@@ -105,10 +106,13 @@ class ResourceIntegrationTest(TestCase):
         self.assertEqual(minimal_response.status_code, 200)
         self.assertEqual(minimal_response.get_json(), data)
         bad_response = self.client().get(self.conversion_route, query_string=bad_params)
+        same_response = self.client().get(self.conversion_route, query_string=same_params)
         self.assertEqual(bad_response.status_code, 400)
+        self.assertEqual(same_response.status_code, 400)
         missing_response = self.client().get(
             self.conversion_route, query_string=missing_params)
         self.assertEqual(missing_response.status_code, 404)
+        
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update the docs with a link to the blog and make a small fix that prevents making a transducer with the same language, i.e. `transducer = make_g2p('alq', 'alq')` throws an exception now whereas before it just caused a nasty 500 error in the API (and the default transducer in the interactive documentation was between 'alq' and 'alq')