### PR TITLE
fix: lock click==8.0.4 since we support Python 3.6

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 openpyxl
-click
+click==8.0.4
 coloredlogs<=14.0
 dnspython>=2.1.0
 eventlet>=0.33.0


### PR DESCRIPTION
The click change log https://python.libhunt.com/click-changelog says
that release v8.1.0 drops support for Python 3.6, but we're still
officially supporting Python 3.6 for g2p, so we need to lock the click
version accordingly.
