### PR TITLE
feat: g2p show-mappings

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -17,13 +17,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
         twine upload dist/*
     - name: trigger convertextract build
       run: |

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -1,6 +1,8 @@
+import json
 import os
 import pprint
 import re
+import sys
 
 import click
 import yaml
@@ -11,7 +13,7 @@ from g2p import make_g2p
 from g2p._version import VERSION
 from g2p.api import update_docs
 from g2p.app import APP, network_to_echart
-from g2p.exceptions import MappingMissing
+from g2p.exceptions import InvalidLanguageCode, MappingMissing, NoPath
 from g2p.log import LOGGER
 from g2p.mappings import Mapping
 from g2p.mappings.create_fallback_mapping import (
@@ -19,9 +21,9 @@ from g2p.mappings.create_fallback_mapping import (
     align_to_dummy_fallback,
 )
 from g2p.mappings.create_ipa_mapping import (
+    DISTANCE_METRICS,
     create_mapping,
     create_multi_mapping,
-    DISTANCE_METRICS,
 )
 from g2p.mappings.langs import LANGS_NETWORK, MAPPINGS_AVAILABLE, cache_langs
 from g2p.mappings.langs.utils import check_ipa_known_segs
@@ -142,12 +144,8 @@ def cli():
     default=False,
     help="Merge multiple mappings together, in which case IN_LANG is a colon-seperated list and OUT_LANG is required.",
 )
-@click.argument(
-    "out_lang", required=False, default=None, type=str,
-)
-@click.argument(
-    "in_lang", required=False, default=None, type=str,
-)
+@click.argument("out_lang", required=False, default=None, type=str)
+@click.argument("in_lang", required=False, default=None, type=str)
 @cli.command(
     context_settings=CONTEXT_SETTINGS,
     short_help="Generate English IPA or dummy mapping.",
@@ -170,102 +168,102 @@ def generate_mapping(
     to_langs,
     distance,
 ):
-    """ Generate a new mapping from existing mappings in the g2p system.
+    """Generate a new mapping from existing mappings in the g2p system.
 
-        This command has different modes of operation.
+    This command has different modes of operation.
 
-        Standard mode:
+    Standard mode:
 
-          g2p generate-mapping [--dummy|--ipa] IN_LANG [OUT_LANG]
+      g2p generate-mapping [--dummy|--ipa] IN_LANG [OUT_LANG]
 
-          For specified IN_LANG, generate a mapping from IN_LANG-ipa to eng-ipa,
-          or from IN_LANG-ipa to a dummy minimalist phone inventory. This assumes
-          the mapping IN_LANG -> IN_LANG-ipa exists and creates a mapping from its
-          output inventory.
+      For specified IN_LANG, generate a mapping from IN_LANG-ipa to eng-ipa,
+      or from IN_LANG-ipa to a dummy minimalist phone inventory. This assumes
+      the mapping IN_LANG -> IN_LANG-ipa exists and creates a mapping from its
+      output inventory.
 
-          To generate a mapping from IN_LANG-ipa to eng-ipa from a mapping
-          following a different patterns, e.g., from crl-equiv -> crl-ipa, specify
-          both IN_LANG (crl-equiv in this example) and OUT_LANG (crl-ipa in this
-          example).
+      To generate a mapping from IN_LANG-ipa to eng-ipa from a mapping
+      following a different patterns, e.g., from crl-equiv -> crl-ipa, specify
+      both IN_LANG (crl-equiv in this example) and OUT_LANG (crl-ipa in this
+      example).
 
-          \b
-          Sample usage:
-            Generate Algonquin IPA to English IPA from alq -> alq-ipa:
-                g2p generate-mapping --ipa alq
-            Generate Mohawk IPA to English IPA from moh-equiv -> moh-ipa:
-                g2p generate-mapping --ipa moh-equiv moh-ipa
-            Generate Michif IPA to English IPA from the union of crg-dv -> crg-ipa
-            and crg-tmd -> crg-ipa:
-                g2p generate-mapping --ipa --merge crg-dv:crg-tmd crg-ipa
+      \b
+      Sample usage:
+        Generate Algonquin IPA to English IPA from alq -> alq-ipa:
+            g2p generate-mapping --ipa alq
+        Generate Mohawk IPA to English IPA from moh-equiv -> moh-ipa:
+            g2p generate-mapping --ipa moh-equiv moh-ipa
+        Generate Michif IPA to English IPA from the union of crg-dv -> crg-ipa
+        and crg-tmd -> crg-ipa:
+            g2p generate-mapping --ipa --merge crg-dv:crg-tmd crg-ipa
 
-        List the dummy inventory used by --dummy:
+    List the dummy inventory used by --dummy:
 
-          g2p generate-mapping --list-dummy
+      g2p generate-mapping --list-dummy
 
-        From/to IPA mode:
+    From/to IPA mode:
 
-        \b
-          g2p generate-mapping --from FROM_L1 --to TO_L1
-          g2p generate-mapping --from FROM_L1:FROM_L2:... --to TO_L1:TO_L2:...
+    \b
+      g2p generate-mapping --from FROM_L1 --to TO_L1
+      g2p generate-mapping --from FROM_L1:FROM_L2:... --to TO_L1:TO_L2:...
 
-          Generate an IPA mapping from the union of FROM_L1-ipa, FROM-L2-ipa, etc to
-          the union of TO_L1-ipa, TO-L2-ipa, etc. One or more from/to language
-          code(s) can be specified in colon- or comma-separated lists. Note, by default
-          we use Panphon's weighted_feature_edit_distance, but you can change this with
-          the --distance argument
+      Generate an IPA mapping from the union of FROM_L1-ipa, FROM-L2-ipa, etc to
+      the union of TO_L1-ipa, TO-L2-ipa, etc. One or more from/to language
+      code(s) can be specified in colon- or comma-separated lists. Note, by default
+      we use Panphon's weighted_feature_edit_distance, but you can change this with
+      the --distance argument
 
-        \b
-          Sample usage:
-            Generate a mapping from kwk-ipa to moh-ipa based on all mappings into
-            kwk-ipa and moh-ipa:
-                g2p generate-mapping --from kwk --to moh
-            Generate a mapping from eng-ipa to crg-ipa based only on crg-dv -> crg-ipa:
-                g2p generate-mapping --from eng --to crg-dv_to_crg-ipa
-            Generate a mapping from kwk-ipa to moh-ipa+crg-ipa+eng-ipa based on
-            all mappings into kwk-ipa (from side) and the union of all mappings
-            into moh-ipa and crg-ipa plus eng-ipa_to_eng-arpabet (to side):
-                g2p generate-mapping --from kwk --to moh:crg:eng
+    \b
+      Sample usage:
+        Generate a mapping from kwk-ipa to moh-ipa based on all mappings into
+        kwk-ipa and moh-ipa:
+            g2p generate-mapping --from kwk --to moh
+        Generate a mapping from eng-ipa to crg-ipa based only on crg-dv -> crg-ipa:
+            g2p generate-mapping --from eng --to crg-dv_to_crg-ipa
+        Generate a mapping from kwk-ipa to moh-ipa+crg-ipa+eng-ipa based on
+        all mappings into kwk-ipa (from side) and the union of all mappings
+        into moh-ipa and crg-ipa plus eng-ipa_to_eng-arpabet (to side):
+            g2p generate-mapping --from kwk --to moh:crg:eng
 
-          Full syntax for specifying FROM_Ln and TO_Ln:
+      Full syntax for specifying FROM_Ln and TO_Ln:
 
-          \b
-            lang (i.e., 3-letter code):
-             - If there is only one mapping into lang-ipa, "lang" refers to the
-               output of that mapping, e.g., "fra" means "fra_to_fra-ipa[out]".
-             - If there are several mappings into lang-ipa, "lang" refers to the
-               union of the outputs of those mappings, e.g., "moh" means the union
-               of "moh-equiv_to_moh-ipa[out]" and "moh-festival_to_moh-ipa[out]".
-             - It is an error if there are no mappings into lang-ipa.
-             - Only mappings from non-IPA to IPA are considered (i.e., IPA-to-IPA
-               mappings created by this command will not be included: use the
-               longer syntax below if you want to use them).
-             - Special case: "eng" refers to "eng-ipa_to_eng-arpabet[in]".
+      \b
+        lang (i.e., 3-letter code):
+         - If there is only one mapping into lang-ipa, "lang" refers to the
+           output of that mapping, e.g., "fra" means "fra_to_fra-ipa[out]".
+         - If there are several mappings into lang-ipa, "lang" refers to the
+           union of the outputs of those mappings, e.g., "moh" means the union
+           of "moh-equiv_to_moh-ipa[out]" and "moh-festival_to_moh-ipa[out]".
+         - It is an error if there are no mappings into lang-ipa.
+         - Only mappings from non-IPA to IPA are considered (i.e., IPA-to-IPA
+           mappings created by this command will not be included: use the
+           longer syntax below if you want to use them).
+         - Special case: "eng" refers to "eng-ipa_to_eng-arpabet[in]".
 
-          \b
-            in-lang_to_out-lang[[in]|[out]]:
-             - This expanded syntax is used to avoid the union when it is not
-               desired, e.g., "moh-equiv_to_moh-ipa" refers only to
-               "moh-equiv_to_moh-ipa,out" rather than the union "moh" represents.
-             - If out-lang is IPA, the output inventory is used; else if in-lang
-               is IPA, the input inventory is used; it is an error if neither
-               language is IPA.
-             - Specify "[in]" or "[out]" to override the above default.
-             - "_to_" is the joiner used to specify "the mapping from 'in-lang' to
-               'out-lang'" in the g2p network, regardless of the name of the file
-               it is stored in.
+      \b
+        in-lang_to_out-lang[[in]|[out]]:
+         - This expanded syntax is used to avoid the union when it is not
+           desired, e.g., "moh-equiv_to_moh-ipa" refers only to
+           "moh-equiv_to_moh-ipa,out" rather than the union "moh" represents.
+         - If out-lang is IPA, the output inventory is used; else if in-lang
+           is IPA, the input inventory is used; it is an error if neither
+           language is IPA.
+         - Specify "[in]" or "[out]" to override the above default.
+         - "_to_" is the joiner used to specify "the mapping from 'in-lang' to
+           'out-lang'" in the g2p network, regardless of the name of the file
+           it is stored in.
 
-        If you just modified or created the mappings from which the new mapping is
-        to be generated, don't forget to call "g2p update" first, so that "g2p
-        generate-mapping" can see the latest version.
+    If you just modified or created the mappings from which the new mapping is
+    to be generated, don't forget to call "g2p update" first, so that "g2p
+    generate-mapping" can see the latest version.
 
-        Call "g2p update" again after calling "g2p generate-mapping" to compile
-        the newly generated mapping and make it available.
+    Call "g2p update" again after calling "g2p generate-mapping" to compile
+    the newly generated mapping and make it available.
 
-        Note: exactly one of --ipa, --dummy, --from/--to, or --list-dummy is
-        required.
+    Note: exactly one of --ipa, --dummy, --from/--to, or --list-dummy is
+    required.
 
-        You can list available mappings with "g2p doctor --list-ipa", or by
-        visiting http://g2p-studio.herokuapp.com/api/v1/langs .
+    You can list available mappings with "g2p doctor --list-ipa", or by
+    visiting http://g2p-studio.herokuapp.com/api/v1/langs .
     """
 
     # Make sure only one mode was specified on the command line
@@ -420,8 +418,7 @@ def generate_mapping(
 @click.argument("path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
 @cli.command(context_settings=CONTEXT_SETTINGS)
 def generate_mapping_network(path):
-    """Generate a png of the network of mapping languages. Requires matplotlib.
-    """
+    """Generate a png of the network of mapping languages. Requires matplotlib."""
     import matplotlib.pyplot as plt
 
     draw(LANGS_NETWORK, with_labels=True)
@@ -450,7 +447,9 @@ def generate_mapping_network(path):
     help="Check IPA outputs against panphon and/or eng-arpabet output against ARPABET",
 )
 @click.option(
-    "--tok-lang", default=None, help="Override the tokenizing language. Implies --tok.",
+    "--tok-lang",
+    default=None,
+    help="Override the tokenizing language. Implies --tok.",
 )
 @click.option(
     "--tok/--no-tok",
@@ -490,11 +489,11 @@ def convert(
 ):
     """Convert INPUT_TEXT through g2p mapping(s) from IN_LANG to OUT_LANG.
 
-       Visit http://g2p-studio.herokuapp.com/api/v1/langs for a list of languages.
+    Visit http://g2p-studio.herokuapp.com/api/v1/langs for a list of languages.
 
-       There must be a path from IN_LANG to OUT_LANG, possibly via some intermediates.
-       For example, mapping from fra to eng-arpabet will successively apply
-       fra->fra-ipa, fra-ipa->eng-ipa and eng-ipa->eng-arpabet.
+    There must be a path from IN_LANG to OUT_LANG, possibly via some intermediates.
+    For example, mapping from fra to eng-arpabet will successively apply
+    fra->fra-ipa, fra-ipa->eng-ipa and eng-ipa->eng-arpabet.
     """
     # Check valid input
     # Check input != output
@@ -579,13 +578,14 @@ def convert(
 )
 @cli.command(context_settings=CONTEXT_SETTINGS)
 def doctor(mapping, list_all, list_ipa):
-    """ Check for common errors in mappings.
-        There should eventually be more checks here, but doctor currently checks for:
+    """Check for common errors in mappings.
 
-        1. Characters that are in IPA mappings but are not recognized by panphon library.
+    There should eventually be more checks here, but doctor currently checks for:
 
-        You can list available mappings with --list-all or --list-ipa, or by visiting
-        http://g2p-studio.herokuapp.com/api/v1/langs .
+    1. Characters that are in IPA mappings but are not recognized by panphon library.
+
+    You can list available mappings with --list-all or --list-ipa, or by visiting
+    http://g2p-studio.herokuapp.com/api/v1/langs .
     """
     if list_all or list_ipa:
         out_langs = sorted({x["out_lang"] for x in MAPPINGS_AVAILABLE})
@@ -627,8 +627,7 @@ def doctor(mapping, list_all, list_ipa):
 
 @cli.command(context_settings=CONTEXT_SETTINGS)
 def update():
-    """ Update cached language files
-    """
+    """Update cached language files."""
     cache_langs()
     update_docs()
     network_to_echart(write_to_file=True)
@@ -638,11 +637,13 @@ def update():
 @click.argument("lang")
 @cli.command(
     context_settings=CONTEXT_SETTINGS,
-    short_help="Scan a document for non target language characters.",
+    short_help="Scan a document for unknown characters.",
 )
 def scan(lang, path):
-    """ Returns the set of non-mapped characters in a document.
-        Accounts for case sensitivity in the configuration.
+    """Scan a document for non target language characters.
+
+    Displays the set of un-mapped characters in a document.
+    Accounts for case sensitivity in the configuration.
     """
     # Check input lang exists
     if not lang in LANGS_NETWORK.nodes:
@@ -677,3 +678,62 @@ def scan(lang, path):
         if unmapped:
             LOGGER.warning("The following characters are not mapped:")
             print(unmapped)
+
+
+@click.option(
+    "-a",
+    "--all",
+    "all_mappings",
+    is_flag=True,
+    help="Display all mappings in the database",
+)
+@click.argument("lang2", required=False, default=None)
+@click.argument("lang1", required=False, default=None)
+@cli.command(context_settings=CONTEXT_SETTINGS, short_help="Show cached mappings.")
+def show_mappings(all_mappings, lang1, lang2):
+    """Show cached mappings, as last updated by "g2p update".
+
+    Mappings on the path from LANG1 to LANG2 are displayed.
+    If only LANG1 is used, all mappings to or from LANG1 are displayed.
+    With --all, all mappings in the database are displayed.
+    """
+
+    if all_mappings:
+        mappings = (
+            Mapping(in_lang=m["in_lang"], out_lang=m["out_lang"])
+            for m in MAPPINGS_AVAILABLE
+        )
+
+    elif lang1 is not None and lang2 is not None:
+        try:
+            transducer = make_g2p(lang1, lang2)
+        except (NoPath, InvalidLanguageCode) as e:
+            raise click.UsageError(
+                f'Cannot find mapping from "{lang1}" to "{lang2}": {e}'
+            ) from e
+
+        if isinstance(transducer, Transducer):
+            mappings = [transducer.mapping]
+        else:
+            mappings = (t.mapping for t in transducer._transducers)
+
+    elif lang1 is not None:
+        mappings = [
+            Mapping(in_lang=m["in_lang"], out_lang=m["out_lang"])
+            for m in MAPPINGS_AVAILABLE
+            if m["in_lang"] == lang1 or m["out_lang"] == lang1
+        ]
+        if not mappings:
+            raise click.BadParameter(
+                f'No mapping found to or from "{lang1}".', param_hint="lang1"
+            )
+
+    else:
+        raise click.UsageError("Nothing to do!")
+
+    for m in mappings:
+        json.dump(m.kwargs, sys.stdout, indent=4, ensure_ascii=False)
+        print()
+        m.mapping_to_stream(sys.stdout)
+        print()
+        print()

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -414,11 +414,12 @@ def generate_mapping(
             new_mapping.mapping_to_file()
 
 
-# TODO the path argument is ignored. What was it supposed to do? Code it...
-@click.argument("path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
-@cli.command(context_settings=CONTEXT_SETTINGS)
-def generate_mapping_network(path):
-    """Generate a png of the network of mapping languages. Requires matplotlib."""
+@cli.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help="Generate an image of the mapping network.",
+)
+def generate_mapping_network():
+    """Generate a png image of the network of language mappings. Requires matplotlib."""
     import matplotlib.pyplot as plt
 
     draw(LANGS_NETWORK, with_labels=True)
@@ -681,21 +682,17 @@ def scan(lang, path):
 
 
 @click.option(
-    "-a",
-    "--all",
-    "all_mappings",
-    is_flag=True,
-    help="Display all mappings in the database",
+    "--all", "all_mappings", is_flag=True, help="Display all cached mappings."
 )
+@click.option("--csv", is_flag=True, help="Output mappings in CSV format.")
 @click.argument("lang2", required=False, default=None)
 @click.argument("lang1", required=False, default=None)
 @cli.command(context_settings=CONTEXT_SETTINGS, short_help="Show cached mappings.")
-def show_mappings(all_mappings, lang1, lang2):
+def show_mappings(lang1, lang2, all_mappings, csv):
     """Show cached mappings, as last updated by "g2p update".
 
     Mappings on the path from LANG1 to LANG2 are displayed.
     If only LANG1 is used, all mappings to or from LANG1 are displayed.
-    With --all, all mappings in the database are displayed.
     """
 
     if all_mappings:
@@ -731,9 +728,10 @@ def show_mappings(all_mappings, lang1, lang2):
     else:
         raise click.UsageError("Nothing to do!")
 
+    file_type = "csv" if csv else "json"
     for m in mappings:
         json.dump(m.kwargs, sys.stdout, indent=4, ensure_ascii=False)
         print()
-        m.mapping_to_stream(sys.stdout)
+        m.mapping_to_stream(sys.stdout, file_type=file_type)
         print()
         print()

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -414,18 +414,6 @@ def generate_mapping(
             new_mapping.mapping_to_file()
 
 
-@cli.command(
-    context_settings=CONTEXT_SETTINGS,
-    short_help="Generate an image of the mapping network.",
-)
-def generate_mapping_network():
-    """Generate a png image of the network of language mappings. Requires matplotlib."""
-    import matplotlib.pyplot as plt
-
-    draw(LANGS_NETWORK, with_labels=True)
-    plt.show()
-
-
 @click.option(
     "--pretty-edges",
     "-e",

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -670,7 +670,12 @@ def scan(lang, path):
 
 
 @click.option("--csv", is_flag=True, help="Output mappings in CSV format.")
-@click.option("--verbose", is_flag=True, help="Output verbose cached")
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Display mapping configs and all rules too.",
+)
 @click.argument("lang2", required=False, default=None)
 @click.argument("lang1", required=False, default=None)
 @cli.command(context_settings=CONTEXT_SETTINGS, short_help="Show cached mappings.")
@@ -679,6 +684,7 @@ def show_mappings(lang1, lang2, verbose, csv):
 
     Mappings on the path from LANG1 to LANG2 are displayed.
     If only LANG1 is used, all mappings to or from LANG1 are displayed.
+    With no LANG, all cached mappings are included.
     """
 
     if lang1 is not None and lang2 is not None:

--- a/g2p/mappings/__init__.py
+++ b/g2p/mappings/__init__.py
@@ -239,14 +239,18 @@ class Mapping:
         # Merge kwargs, but prioritize kwargs that initialized the Mapping
         self.kwargs = {**mapping_kwargs, **self.kwargs}
 
-    def plain_mapping(self, skip_empty_contexts=False):
-        """Return the plain mapping for displaying or save to disk."""
-        internal_fields = ["match_pattern", "intermediate_form"]
+    def plain_mapping(self, skip_empty_contexts: bool = False):
+        """Return the plain mapping for displaying or saving to disk.
+
+        Args:
+            skip_empty_contexts: when set, filter out empty context_before/after
+        """
         return [
             {
                 k: v
                 for k, v in io.items()
-                if k not in internal_fields and (not skip_empty_contexts or "context_" not in k or v != "")
+                if k not in ["match_pattern", "intermediate_form"]
+                and (not skip_empty_contexts or k[:8] != "context_" or v != "")
             }
             for io in self.mapping
         ]
@@ -439,7 +443,9 @@ class Mapping:
             )
         elif file_type == "csv":
             fieldnames = ["in", "out", "context_before", "context_after"]
-            writer = csv.DictWriter(out_stream, fieldnames=fieldnames, extrasaction="ignore")
+            writer = csv.DictWriter(
+                out_stream, fieldnames=fieldnames, extrasaction="ignore"
+            )
             for io in self.mapping:
                 writer.writerow(io)
         else:

--- a/g2p/tests/public/mappings/gm1-ipa_to_gm2-ipa.json
+++ b/g2p/tests/public/mappings/gm1-ipa_to_gm2-ipa.json
@@ -1,6 +1,6 @@
 [
-    {"in": "e", "out": "ɛ", "context_before": "", "context_after": ""},
-    {"in": "o", "out": "ɔ", "context_before": "", "context_after": ""},
-    {"in": "b", "out": "d", "context_before": "", "context_after": ""},
-    {"in": "l", "out": "n", "context_before": "", "context_after": ""}
+    {"in": "e", "out": "ɛ"},
+    {"in": "o", "out": "ɔ"},
+    {"in": "b", "out": "d"},
+    {"in": "l", "out": "n"}
 ]

--- a/g2p/tests/public/mappings/gm2-ipa_to_gm3-ipa.json
+++ b/g2p/tests/public/mappings/gm2-ipa_to_gm3-ipa.json
@@ -1,6 +1,6 @@
 [
-    {"in": "ɛ", "out": "i", "context_before": "", "context_after": ""},
-    {"in": "ɔ", "out": "o", "context_before": "", "context_after": ""},
-    {"in": "d", "out": "s", "context_before": "", "context_after": ""},
-    {"in": "n", "out": "m", "context_before": "", "context_after": ""}
+    {"in": "ɛ", "out": "i"},
+    {"in": "ɔ", "out": "o"},
+    {"in": "d", "out": "s"},
+    {"in": "n", "out": "m"}
 ]

--- a/g2p/tests/public/mappings/gm3-ipa_to_gm2-ipa.json
+++ b/g2p/tests/public/mappings/gm3-ipa_to_gm2-ipa.json
@@ -1,10 +1,10 @@
 [
-    {"in": "i", "out": "ɛ", "context_before": "", "context_after": ""},
-    {"in": "o", "out": "ɔ", "context_before": "", "context_after": ""},
-    {"in": "k", "out": "d", "context_before": "", "context_after": ""},
-    {"in": "m", "out": "n", "context_before": "", "context_after": ""},
-    {"in": "u", "out": "ɔ", "context_before": "", "context_after": ""},
-    {"in": "y", "out": "ɛ", "context_before": "", "context_after": ""},
-    {"in": "s", "out": "d", "context_before": "", "context_after": ""},
-    {"in": "ɲ", "out": "n", "context_before": "", "context_after": ""}
+    {"in": "i", "out": "ɛ"},
+    {"in": "o", "out": "ɔ"},
+    {"in": "k", "out": "d"},
+    {"in": "m", "out": "n"},
+    {"in": "u", "out": "ɔ"},
+    {"in": "y", "out": "ɛ"},
+    {"in": "s", "out": "d"},
+    {"in": "ɲ", "out": "n"}
 ]

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -284,6 +284,14 @@ class CliTest(TestCase):
         self.assertEqual(results.exit_code, 0)
         self.assertGreater(len(re.findall(r"display_name", results.output)), 100)
 
+        # --csv = CSV formatted output
+        results = self.runner.invoke(show_mappings, ["--csv", "crl-equiv"])
+        self.assertEqual(results.exit_code, 0)
+        self.assertIn("Northern East Cree Equivalencies", results.output)
+        self.assertIn("Northern East Cree to IPA", results.output)
+        self.assertIn("thwaa,ᕨ,,", results.output)
+        self.assertIn("ᐧᕓ,vʷeː,,", results.output)
+
         # No args = error
         results = self.runner.invoke(show_mappings, [])
         self.assertNotEqual(results.exit_code, 0)

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -263,14 +263,21 @@ class CliTest(TestCase):
 
     def test_show_mappings(self):
         # One arg = all mappings to or from that language
-        results = self.runner.invoke(show_mappings, ["fra-ipa"])
+        results = self.runner.invoke(show_mappings, ["fra-ipa", "--verbose"])
         self.assertEqual(results.exit_code, 0)
         self.assertIn("French to IPA", results.output)
         self.assertIn("French IPA to English IPA", results.output)
         self.assertEqual(len(re.findall(r"display_name", results.output)), 2)
 
+        # One arg = all mappings to or from that language, terse output
+        results = self.runner.invoke(show_mappings, ["fra-ipa"])
+        self.assertEqual(results.exit_code, 0)
+        self.assertIn("fra-ipa", results.output)
+        self.assertIn("eng-ipa", results.output)
+        self.assertEqual(len(re.findall(r"→", results.output)), 2)
+
         # Two conencted args = that mapping
-        results = self.runner.invoke(show_mappings, ["fra", "fra-ipa"])
+        results = self.runner.invoke(show_mappings, ["fra", "fra-ipa", "--verbose"])
         self.assertEqual(results.exit_code, 0)
         self.assertIn("French to IPA", results.output)
         self.assertIn(r'{"in": "&", "out": "et"},', results.output)
@@ -285,7 +292,7 @@ class CliTest(TestCase):
         self.assertEqual(len(re.findall(r"display_name", results.output)), 1)
 
         # Two args connected via a intermediate steps = all mappings on that path
-        results = self.runner.invoke(show_mappings, ["fra", "eng-arpabet"])
+        results = self.runner.invoke(show_mappings, ["fra", "eng-arpabet", "--verbose"])
         self.assertEqual(results.exit_code, 0)
         self.assertIn("French to IPA", results.output)
         self.assertIn("French IPA to English IPA", results.output)
@@ -293,21 +300,17 @@ class CliTest(TestCase):
         self.assertEqual(len(re.findall(r"display_name", results.output)), 3)
 
         # --all = all mappings
-        results = self.runner.invoke(show_mappings, ["--all"])
+        results = self.runner.invoke(show_mappings, [])
         self.assertEqual(results.exit_code, 0)
-        self.assertGreater(len(re.findall(r"display_name", results.output)), 100)
+        self.assertGreater(len(re.findall(r"→", results.output)), 100)
 
         # --csv = CSV formatted output
-        results = self.runner.invoke(show_mappings, ["--csv", "crl-equiv"])
+        results = self.runner.invoke(show_mappings, ["--csv", "crl-equiv", "--verbose"])
         self.assertEqual(results.exit_code, 0)
         self.assertIn("Northern East Cree Equivalencies", results.output)
         self.assertIn("thwaa,ᕨ,,", results.output)
         self.assertIn("Northern East Cree to IPA", results.output)
         self.assertIn("ᐧᕓ,vʷeː,,", results.output)
-
-        # No args = error
-        results = self.runner.invoke(show_mappings, [])
-        self.assertNotEqual(results.exit_code, 0)
 
         # Bad language code
         results = self.runner.invoke(show_mappings, ["not-a-lang"])

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -241,7 +241,9 @@ class CliTest(TestCase):
         self.assertNotEqual(results.exit_code, 0)
         self.assertIn("Error: --from and --to must be used together", results.output)
 
-        results = self.runner.invoke(generate_mapping, "--from fra_to_fra-ipa --to haa_to_haa-equiv")
+        results = self.runner.invoke(
+            generate_mapping, "--from fra_to_fra-ipa --to haa_to_haa-equiv"
+        )
         self.assertNotEqual(results.exit_code, 0)
         self.assertIn("Cannot guess in/out for IPA lang spec", results.output)
 
@@ -249,7 +251,9 @@ class CliTest(TestCase):
         self.assertNotEqual(results.exit_code, 0)
         self.assertIn("is only supported with the full", results.output)
 
-        results = self.runner.invoke(generate_mapping, "--from fra_to_fra-ipa[foo] --to eng")
+        results = self.runner.invoke(
+            generate_mapping, "--from fra_to_fra-ipa[foo] --to eng"
+        )
         self.assertNotEqual(results.exit_code, 0)
         self.assertIn("is allowed in square brackets", results.output)
 
@@ -269,6 +273,15 @@ class CliTest(TestCase):
         results = self.runner.invoke(show_mappings, ["fra", "fra-ipa"])
         self.assertEqual(results.exit_code, 0)
         self.assertIn("French to IPA", results.output)
+        self.assertIn(r'{"in": "&", "out": "et"},', results.output)
+        self.assertIn(
+            r'{"in": "c", "out": "s", "context_after": "e|i|è|é|ê|ë|î|ï|ÿ"},',
+            results.output,
+        )
+        self.assertIn(
+            r'{"in": "e", "out": "", "context_before": "\\S", "context_after": "\\b"},',
+            results.output,
+        )
         self.assertEqual(len(re.findall(r"display_name", results.output)), 1)
 
         # Two args connected via a intermediate steps = all mappings on that path
@@ -288,8 +301,8 @@ class CliTest(TestCase):
         results = self.runner.invoke(show_mappings, ["--csv", "crl-equiv"])
         self.assertEqual(results.exit_code, 0)
         self.assertIn("Northern East Cree Equivalencies", results.output)
-        self.assertIn("Northern East Cree to IPA", results.output)
         self.assertIn("thwaa,ᕨ,,", results.output)
+        self.assertIn("Northern East Cree to IPA", results.output)
         self.assertIn("ᐧᕓ,vʷeː,,", results.output)
 
         # No args = error

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,15 @@ setup(
     description="Module for creating context-aware, rule-based G2P mappings that preserve indices",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    platform=["any"],
     packages=find_packages(),
     include_package_data=True,
     install_requires=REQS,
     entry_points={"console_scripts": ["g2p = g2p.cli:cli"]},
     zip_safe=False,
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
 )


### PR DESCRIPTION
When debugging g2p, I often find I'd like to know what's actually in the cached mappings at a given commit or in a given sandbox. `g2p show-mappings` does just that: dump to screen the stuff that `g2p update` last saved.

Other change: when `context_before` and `context_after` are actually empty, don't print to with `g2p show-mappings` and don't include them in the files generated by `g2p generate-mapping`.