### PR TITLE
ci: publish with build instead of calling setup.py directly

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -17,13 +17,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build --sdist --wheel
         twine upload dist/*
     - name: trigger convertextract build
       run: |

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,15 @@ setup(
     description="Module for creating context-aware, rule-based G2P mappings that preserve indices",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    platform=["any"],
     packages=find_packages(),
     include_package_data=True,
     install_requires=REQS,
     entry_points={"console_scripts": ["g2p = g2p.cli:cli"]},
     zip_safe=False,
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
 )


### PR DESCRIPTION
According to https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
calling `python setup.py` has been deprecated for a while, and should be
avoided. The recommended replacement is

    python -b build --sdist --wheel

which still uses the setup.py file, but in the way that is now considered
correct.  This commits introduces that method. The build command was tested in
ReadAlongs/Studio branch dev.test-build, with the results visible here:
https://github.com/ReadAlongs/Studio/actions?query=branch%3Adev.test-build

Other changes:
 - have setup.py declare platform and classifiers