### PR TITLE
Update pip before use

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,12 @@ jobs:
           python-version: "3.6"
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip
           pip3 install -r requirements.txt
           pip3 install -e .
           pip3 install pip-licenses
           if pip-licenses | grep -v 'Artistic License' | grep -v LGPL | grep GNU; then echo 'Please avoid introducing *GPL dependencies'; false; fi
-          pip3 install coverage
-          pip3 install coveralls
+          pip3 install coverage coveralls
       - name: Run tests
         run: |
           gunicorn --worker-class eventlet  -w 1 g2p.app:APP --no-sendfile --bind 0.0.0.0:5000 --daemon

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,30 @@ FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Dependencies that don't change with g2p updates and can be cached
-RUN apt-get update -y && apt-get install -y apt-transport-https
-RUN apt-get install -y libffi-dev openssl libssl-dev python3 python3-pip python3-dev build-essential nano git
+# Dependencies that don't change with g2p updates and can be cached, and make it lean
+run apt-get update -y \
+    && apt-get install -y \
+        apt-transport-https \
+        libffi-dev \
+        openssl \
+        libssl-dev \
+        python3 \
+        python3-pip \
+        python3-dev \
+        build-essential \
+        nano \
+        git \
+    && apt-get clean \
+    && apt-get autoremove \
+    && rm -fr /var/lib/apt/lists/*
 
 # Get g2p-specific dependencies that can also often be cached
 RUN mkdir -p /g2p/g2p
 COPY requirements /g2p/requirements
 COPY requirements.txt /g2p
 COPY setup.py /g2p
-RUN MAKEFLAGS="-j$(nproc)" pip3 install -r /g2p/requirements.txt
+RUN python3 -m pip install --upgrade pip \
+    && MAKEFLAGS="-j$(nproc)" pip3 install -r /g2p/requirements.txt
 
 # Install g2p itself, last
 COPY g2p /g2p/g2p

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -1,5 +1,7 @@
 black~=22.0
 flake8>=4.0.1
-isort>=5.10.1
-types-PyYAML
 gitlint-core==0.17.0
+isort>=5.10.1
+mypy>=0.941
+pre-commit>=2.6.0
+types-PyYAML


### PR DESCRIPTION
It's best practice to update pip to the latest version before using it.

Update our Dockerfiles and tests CI workflow accordingly.