### PR TITLE
Add CI testing on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.6"
       - name: Install dependencies
@@ -29,3 +29,18 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true # optional (default = false)
+
+  test-on-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.6"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install -e .
+      - name: Run tests on Windows
+        run: python run_tests.py dev

--- a/g2p/tests/test_mappings.py
+++ b/g2p/tests/test_mappings.py
@@ -297,13 +297,23 @@ class MappingTest(TestCase):
                          "Jouni hɑluɑː juodɑ kɑhviɑ")
         # Concatenate them (this is not a good idea) and make sure it works anyway
         tf = NamedTemporaryFile(
-            prefix="test_g2p_g2p_", mode="w", suffix=".csv", delete=False
+            prefix="test_g2p_g2p_",
+            mode="w",
+            suffix=".csv",
+            delete=False,
+            encoding="utf8",
         )
-        with open(os.path.join(os.path.dirname(public_data), "mappings", "g2p_studio.csv")) as fh:
+        with open(
+            os.path.join(os.path.dirname(public_data), "mappings", "g2p_studio.csv"),
+            encoding="utf8",
+        ) as fh:
             tf.write(fh.read())
         # In fact you can't concatenate them anyway. They don't end in newline.
         tf.write("\n")
-        with open(os.path.join(os.path.dirname(public_data), "mappings", "g2p_studio2.csv")) as fh:
+        with open(
+            os.path.join(os.path.dirname(public_data), "mappings", "g2p_studio2.csv"),
+            encoding="utf8",
+        ) as fh:
             tf.write(fh.read())
         tf.close()
         mapping = Mapping(tf.name)


### PR DESCRIPTION
Add a second test job in CI to run the test suite on Windows too, since we intend to support Windows.