### PR TITLE
Do full matrix CI on PRs to release

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -1,0 +1,26 @@
+name: Run full matrix Tests before Releases
+on:
+  pull_request:
+    branches: [ release ]
+  push:
+    # for testing this CI while I'm developing it.
+    branches: dev.matrix-ci
+jobs:
+  pre-release-matrix-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install -e .
+      - name: Run tests
+        run: python run_tests.py dev

--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -2,9 +2,6 @@ name: Run full matrix Tests before Releases
 on:
   pull_request:
     branches: [ release ]
-  push:
-    # for testing this CI while I'm developing it.
-    branches: dev.matrix-ci
 jobs:
   pre-release-matrix-test:
     strategy:

--- a/g2p/tests/test_mappings.py
+++ b/g2p/tests/test_mappings.py
@@ -297,13 +297,23 @@ class MappingTest(TestCase):
                          "Jouni hɑluɑː juodɑ kɑhviɑ")
         # Concatenate them (this is not a good idea) and make sure it works anyway
         tf = NamedTemporaryFile(
-            prefix="test_g2p_g2p_", mode="w", suffix=".csv", delete=False
+            prefix="test_g2p_g2p_",
+            mode="w",
+            suffix=".csv",
+            delete=False,
+            encoding="utf8",
         )
-        with open(os.path.join(os.path.dirname(public_data), "mappings", "g2p_studio.csv")) as fh:
+        with open(
+            os.path.join(os.path.dirname(public_data), "mappings", "g2p_studio.csv"),
+            encoding="utf8",
+        ) as fh:
             tf.write(fh.read())
         # In fact you can't concatenate them anyway. They don't end in newline.
         tf.write("\n")
-        with open(os.path.join(os.path.dirname(public_data), "mappings", "g2p_studio2.csv")) as fh:
+        with open(
+            os.path.join(os.path.dirname(public_data), "mappings", "g2p_studio2.csv"),
+            encoding="utf8",
+        ) as fh:
             tf.write(fh.read())
         tf.close()
         mapping = Mapping(tf.name)


### PR DESCRIPTION
Before making a release, let's run the test suite on Windows, MacOS and Ubuntu, with Python versions 3.6 through 3.10.

See https://github.com/roedoejet/g2p/actions/runs/2700305653 for what the action looks like when it fully runs.