### PR TITLE
ci: skip CI tests for commits with #no-ci in the message

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # #no-ci in the commit log flags commit we don't want CI-validated
+    if: ${{ !contains(github.event.head_commit.message, '#no-ci') }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -32,6 +34,7 @@ jobs:
 
   test-on-windows:
     runs-on: windows-latest
+    if: ${{ !contains(github.event.head_commit.message, '#no-ci') }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python


### PR DESCRIPTION
This is just a minor convenience thing I added to Studio CI workflow as well.

When you're doing work in progress and just want to push a backup on a branch you're planning to throw away, add #no-ci to the commit log and CI gets skipped.