### PR TITLE
Dev.studio test

### DIFF
--- a/.github/workflows/studio-release-tests.yml
+++ b/.github/workflows/studio-release-tests.yml
@@ -1,9 +1,11 @@
 name: Run Tests for Studio
 on:
   pull_request:
-    branches: [release]
+    branches: [release, master]
+  push:
+    branches: [release, master]
 jobs:
-  test:
+  test-studio:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -15,10 +17,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip3 install -r requirements.txt
-          pip3 install -r requirements.test.txt
+          pip3 install -r requirements/requirements.test.txt
           pip3 install -e .
-      - name: Ensure browsers are installed
-        run: python -m playwright install --with-deps
+      - name: Ensure browser is installed
+        run: python -m playwright install --with-deps chromium
       - name: Run tests
         run: |
           gunicorn --worker-class eventlet  -w 1 g2p.app:APP --no-sendfile --bind 0.0.0.0:5000 --daemon

--- a/.github/workflows/studio-release-tests.yml
+++ b/.github/workflows/studio-release-tests.yml
@@ -1,0 +1,32 @@
+name: Run Tests for Studio
+on:
+  pull_request:
+    branches: [release]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.6"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install -r requirements.txt
+          pip3 install -r requirements.test.txt
+          pip3 install -e .
+          pip3 install coverage coveralls
+      - name: Ensure browsers are installed
+        run: python -m playwright install --with-deps
+      - name: Run tests
+        run: |
+          gunicorn --worker-class eventlet  -w 1 g2p.app:APP --no-sendfile --bind 0.0.0.0:5000 --daemon
+          sleep 5
+          coverage run run_tests.py release-only
+          coverage xml
+          if git status | grep -E 'static.*json|mapping.*pkl'; then echo 'g2p databases out of date, please run "g2p update" and commit the results.'; false; else echo OK; fi
+      - uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/studio-release-tests.yml
+++ b/.github/workflows/studio-release-tests.yml
@@ -10,23 +10,17 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.6"
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip3 install -r requirements.txt
           pip3 install -r requirements.test.txt
           pip3 install -e .
-          pip3 install coverage coveralls
       - name: Ensure browsers are installed
         run: python -m playwright install --with-deps
       - name: Run tests
         run: |
           gunicorn --worker-class eventlet  -w 1 g2p.app:APP --no-sendfile --bind 0.0.0.0:5000 --daemon
           sleep 5
-          coverage run run_tests.py release-only
-          coverage xml
-          if git status | grep -E 'static.*json|mapping.*pkl'; then echo 'g2p databases out of date, please run "g2p update" and commit the results.'; false; else echo OK; fi
-      - uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: true # optional (default = false)
+          cd g2p/tests && python3 test_studio.py

--- a/g2p/app.py
+++ b/g2p/app.py
@@ -17,7 +17,7 @@ from g2p.api import g2p_api
 from g2p.log import LOGGER
 from g2p.mappings import Mapping
 from g2p.mappings.langs import LANGS_NETWORK
-from g2p.mappings.utils import expand_abbreviations, flatten_abbreviations
+from g2p.mappings.utils import expand_abbreviations_format, flatten_abbreviations_format
 from g2p.static import __file__ as static_file
 from g2p.transducer import (
     CompositeTransducer,
@@ -182,10 +182,11 @@ def docs():
 def convert(message):
     """Convert input text and return output"""
     transducers = []
+
     for mapping in message["data"]["mappings"]:
         mappings_obj = Mapping(
             mapping["mapping"],
-            abbreviations=flatten_abbreviations(mapping["abbreviations"]),
+            abbreviations=flatten_abbreviations_format(mapping["abbreviations"]),
             **mapping["kwargs"],
         )
         transducer = Transducer(mappings_obj)
@@ -225,7 +226,7 @@ def change_table(message):
         [
             {
                 "mappings": x.plain_mapping(),
-                "abbs": expand_abbreviations(x.abbreviations),
+                "abbs": expand_abbreviations_format(x.abbreviations),
                 "kwargs": x.kwargs,
             }
             for x in mappings

--- a/g2p/app.py
+++ b/g2p/app.py
@@ -161,20 +161,6 @@ def return_empty_mappings(n=DEFAULT_N):
     return mappings
 
 
-def hot_to_mappings(hot_data):
-    """Parse data from HandsOnTable to Mapping format"""
-    return [
-        {
-            "context_before": str(x[2] or ""),
-            "in": str(x[0] or ""),
-            "context_after": str(x[3] or ""),
-            "out": str(x[1] or ""),
-        }
-        for x in hot_data
-        if x[0] or x[1]
-    ]
-
-
 def return_descendant_nodes(node: str):
     """Return possible outputs for a given input"""
     return [x for x in descendants(LANGS_NETWORK, node)]
@@ -198,7 +184,7 @@ def convert(message):
     transducers = []
     for mapping in message["data"]["mappings"]:
         mappings_obj = Mapping(
-            hot_to_mappings(mapping["mapping"]),
+            mapping["mapping"],
             abbreviations=flatten_abbreviations(mapping["abbreviations"]),
             **mapping["kwargs"],
         )

--- a/g2p/exceptions.py
+++ b/g2p/exceptions.py
@@ -114,3 +114,12 @@ class InvalidLanguageCode(CommandLineError):
 
     def __str__(self):
         return self.render('No language called: "%(lang)s".')
+
+
+class RecursionError(CommandLineError):
+    def __init__(self, msg):
+        super().__init__(self)
+        self.msg = msg
+
+    def __str__(self):
+        return self.render(self.msg)

--- a/g2p/static/custom.css
+++ b/g2p/static/custom.css
@@ -27,14 +27,28 @@ label {
     overflow-x: hidden;
 }
 
-.mg-top, h4 {
+.mg-top,
+h4 {
     margin-top: 40px;
 }
 
-.hot-container, .settings, .abbs-container {
+.hot-container,
+.settings,
+.abbs-container {
     display: none;
 }
 
-.hot-container.active, .settings.active, .abbs-container.active {
+.hot-container.active,
+.settings.active,
+.abbs-container.active {
     display: inline;
+}
+
+table td {
+    text-align: center;
+    padding: 3px !important;
+}
+
+table th {
+    padding: 3px !important;
 }

--- a/g2p/static/custom.js
+++ b/g2p/static/custom.js
@@ -51,7 +51,7 @@ $(window).on('resize', function() {
 
 function createSettings(index, data) {
     let include = 'checked';
-    let as_is = '';
+    let rule_ordering = '';
     let case_sensitive = '';
     let escape_special = '';
     let reverse = '';
@@ -67,7 +67,9 @@ function createSettings(index, data) {
         include = 'checked'
     }
     if (data['rule_ordering'] === 'as-written') {
-        as_is = 'checked'
+        rule_ordering = 'as-written'
+    } else {
+        rule_ordering = 'longest-first'
     }
     if (data['case_sensitive']) {
         case_sensitive = 'checked'
@@ -99,10 +101,7 @@ function createSettings(index, data) {
                     <input ${include} class='include' id='include-${index}' type='checkbox' name='include' value='include'>
                     <label for='include'>Include rules in output</label>
                 </div>
-                <div>
-                    <input ${as_is} id='as_is-${index}' type='checkbox' name='as_is' value='as_is'>
-                    <label for='as_is'>Leave order as is</label>
-                </div>
+
                 <div>
                     <input  ${case_sensitive} id='case_sensitive-${index}' type='checkbox' name='case_sensitive'
                         value='case_sensitive'>
@@ -119,6 +118,13 @@ function createSettings(index, data) {
                 <div>
                     <input ${prevent_feeding} id='prevent_feeding-${index}' type='checkbox' name='prevent_feeding' value='prevent_feeding'>
                     <label for='prevent_feeding'>Prevent all rules from feeding</label>
+                </div>
+                <div>
+                    <label for='rule_ordering'>Rule Ordering Approach</label>
+                    <select id='rule_ordering-${index}' name='rule_ordering'>
+                    <option ${rule_ordering === 'longest-first' ? "selected" : ""} value='longest-first'>Longest first</option>
+                    <option ${rule_ordering === 'as-written' ? "selected" : ""} value='as-written'>As written</option>
+                    </select>
                 </div>
                 <div>
                     <label for='reverse'>Normalization</label>
@@ -138,13 +144,9 @@ function createSettings(index, data) {
         setKwargs(index, { include })
     })
 
-    document.getElementById(`as_is-${index}`).addEventListener('click', function(event) {
-        const as_is = event.target.checked
-        if (as_is) {
-            setKwargs(index, { rule_ordering: 'as-written' })
-        } else {
-            setKwargs(index, { rule_ordering: 'apply-longest-first' })
-        }
+    $(`#rule_ordering-${index}`).on('change', function(event) {
+        const rule_ordering = $(`#rule_ordering-${index}`).val()
+        setKwargs(index, { rule_ordering })
     })
 
     document.getElementById(`case_sensitive-${index}`).addEventListener('click', function(event) {
@@ -223,7 +225,7 @@ function createTable(index, data) {
     let headerLabels = headers.map(header => header.replace('_', ' ').split(' ').map(x => { return x.charAt(0).toUpperCase() + x.slice(1) }).join(' '))
     var hotSettings = {
         data: data,
-        columns: headers.map(x => { return { 'data': x, type: 'text' } }),
+        columns: headers.map(x => { if (x !== "prevent_feeding") { return { 'data': x, type: 'text' } } else { return { 'data': x, type: 'checkbox' } } }),
         stretchH: 'all',
         width: 880,
         autoWrapRow: true,
@@ -270,7 +272,8 @@ for (var j = 0; j < size; j++) {
         "in": '',
         "out": '',
         "context_before": '',
-        "context_after": ''
+        "context_after": '',
+        "prevent_feeding": false
     });
     if (j === 0) {
         varsObject.push(['Vowels', 'a', 'e', 'i', 'o', 'u'])
@@ -312,9 +315,10 @@ getIncludedMappings = function() {
     let indices = getIncludedIndices()
     let mappings = []
     if (TABLES.length === indices.length && ABBS.length === indices.length) {
+
         for (index of indices) {
             mapping = {}
-            mapping['mapping'] = TABLES[index].getData()
+            mapping['mapping'] = TABLES[index].getSourceData()
             mapping['abbreviations'] = ABBS[index].getData()
             mapping['kwargs'] = getKwargs(index)
             mappings.push(mapping)
@@ -324,7 +328,7 @@ getIncludedMappings = function() {
 }
 
 var getKwargs = function(index) {
-    const as_is = document.getElementById(`as_is-${index}`).checked
+    const rule_ordering = $(`#rule_ordering-${index}`).val()
     const case_sensitive = document.getElementById(`case_sensitive-${index}`).checked
     const escape_special = document.getElementById(`escape_special-${index}`).checked
     const reverse = document.getElementById(`reverse-${index}`).checked
@@ -333,12 +337,12 @@ var getKwargs = function(index) {
     const prevent_feeding = document.getElementById(`prevent_feeding-${index}`).checked
     const norm_form = document.getElementById(`norm_form-${index}`).value
     const type = document.getElementById(`type-${index}`).value
-    return { as_is, case_sensitive, escape_special, reverse, include, out_delimiter, norm_form, prevent_feeding, type }
+    return { rule_ordering, case_sensitive, escape_special, reverse, include, out_delimiter, norm_form, prevent_feeding, type }
 }
 
 var setKwargs = function(index, kwargs) {
-    if ('as_is' in kwargs) {
-        document.getElementById(`as_is-${index}`).checked = kwargs['as_is']
+    if ('rule_ordering' in kwargs) {
+        $(`#rule_ordering-${index}`).val(kwargs['rule_ordering'])
     }
     if ('case_sensitive' in kwargs) {
         document.getElementById(`case_sensitive-${index}`).checked = kwargs['case_sensitive']

--- a/g2p/static/custom.js
+++ b/g2p/static/custom.js
@@ -69,7 +69,7 @@ function createSettings(index, data) {
     if (data['rule_ordering'] === 'as-written') {
         rule_ordering = 'as-written'
     } else {
-        rule_ordering = 'longest-first'
+        rule_ordering = 'apply-longest-first'
     }
     if (data['case_sensitive']) {
         case_sensitive = 'checked'
@@ -77,9 +77,10 @@ function createSettings(index, data) {
     if (data['escape_special']) {
         escape_special = 'checked'
     }
-    if (data['reverse']) {
-        reverse = 'checked'
-    }
+    // Don't reverse because reversed mappings already come reversed
+    // if (data['reverse']) {
+    //     reverse = 'checked'
+    // }
     if (data['prevent_feeding']) {
         prevent_feeding = 'checked'
     }
@@ -122,7 +123,7 @@ function createSettings(index, data) {
                 <div>
                     <label for='rule_ordering'>Rule Ordering Approach</label>
                     <select id='rule_ordering-${index}' name='rule_ordering'>
-                    <option ${rule_ordering === 'longest-first' ? "selected" : ""} value='longest-first'>Longest first</option>
+                    <option ${rule_ordering === 'apply-longest-first' ? "selected" : ""} value='apply-longest-first'>Longest first</option>
                     <option ${rule_ordering === 'as-written' ? "selected" : ""} value='as-written'>As written</option>
                     </select>
                 </div>

--- a/g2p/tests/public/data/__init__.py
+++ b/g2p/tests/public/data/__init__.py
@@ -30,7 +30,7 @@ def load_public_test_data():
         return loaded_langs_to_test
 
     langs_to_test = []
-    for fn in glob(os.path.join(DATA_DIR, "*.*sv")):
+    for fn in sorted(glob(os.path.join(DATA_DIR, "*.*sv"))):
         if fn.endswith("csv"):
             delimiter = ","
         elif fn.endswith("psv"):

--- a/g2p/tests/run.py
+++ b/g2p/tests/run.py
@@ -19,7 +19,6 @@ from g2p.tests.test_indices import IndicesTest
 from g2p.tests.test_langs import LangTest
 from g2p.tests.test_mappings import MappingTest
 from g2p.tests.test_network import NetworkTest
-from g2p.tests.test_studio import StudioTest
 from g2p.tests.test_tokenize_and_map import TokenizeAndMapTest
 from g2p.tests.test_tokenizer import TokenizerTest
 from g2p.tests.test_transducer import TransducerTest
@@ -71,14 +70,6 @@ INTEGRATION_TESTS = [
     ]
 ]
 
-# This test suite spawns a browser and takes a rather long time, so it should only be run on release
-RELEASE_ONLY_TESTS = [
-    LOADER.loadTestsFromTestCase(test)
-    for test in [
-        StudioTest,
-    ]
-]
-
 # LocalConfigTest has to get run last, to avoid interactions with other test
 # cases, since it has side effects on the global database
 LAST_DEV_TEST = [
@@ -107,8 +98,6 @@ def run_tests(suite):
         suite = TestSuite(INTEGRATION_TESTS)
     elif suite == "dev":
         suite = TestSuite(DEV_TESTS)
-    elif suite == "release-only":
-        suite = TestSuite(RELEASE_ONLY_TESTS)
     runner = TextTestRunner(verbosity=3)
     if isinstance(suite, str):
         LOGGER.error("Please specify a test suite to run: i.e. 'dev' or 'all'")

--- a/g2p/tests/run.py
+++ b/g2p/tests/run.py
@@ -67,8 +67,15 @@ INTEGRATION_TESTS = [
     for test in [
         CliTest,
         ResourceIntegrationTest,
-        StudioTest,
         DoctorTest,
+    ]
+]
+
+# This test suite spawns a browser and takes a rather long time, so it should only be run on release
+RELEASE_ONLY_TESTS = [
+    LOADER.loadTestsFromTestCase(test)
+    for test in [
+        StudioTest,
     ]
 ]
 
@@ -100,6 +107,8 @@ def run_tests(suite):
         suite = TestSuite(INTEGRATION_TESTS)
     elif suite == "dev":
         suite = TestSuite(DEV_TESTS)
+    elif suite == "release-only":
+        suite = TestSuite(RELEASE_ONLY_TESTS)
     runner = TextTestRunner(verbosity=3)
     if isinstance(suite, str):
         LOGGER.error("Please specify a test suite to run: i.e. 'dev' or 'all'")

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
-import sys
+
+"""
+Test suite for the g2p-studio web app.
+
+Requirements: python 3.8 and requirements/requirements.test.txt
+
+Before running this test suite, launch the g2p-studio server:
+minimal dev mode:
+    python run_studio.py
+or robust server mode (*nix only, gunicorn does not work on Windows):
+    gunicorn --worker-class eventlet  -w 1 g2p.app:APP --no-sendfile --bind 0.0.0.0:5000 --daemon
+"""
+
+from datetime import datetime
 
 # flake8: noqa: C901
 from unittest import IsolatedAsyncioTestCase, main
@@ -12,12 +25,16 @@ from g2p.tests.public.data import load_public_test_data
 
 
 class StudioTest(IsolatedAsyncioTestCase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.port = 5000
+        self.debug = True
+
     def setUp(self):
         self.flask_test_client = APP.test_client()
         self.socketio_test_client = SOCKETIO.test_client(
             APP, flask_test_client=self.flask_test_client
         )
-        self.debug = True
 
     def test_socket_connection(self):
         self.assertTrue(self.socketio_test_client.is_connected())
@@ -26,7 +43,7 @@ class StudioTest(IsolatedAsyncioTestCase):
         async with async_playwright() as p:
             browser = await p.chromium.launch(channel="chrome", headless=True)
             page = await browser.new_page()
-            await page.goto("http://localhost:5000")
+            await page.goto(f"http://localhost:{self.port}")
             await page.wait_for_timeout(1000)
             input_el = page.locator("#input")
             output_el = page.locator("#output")
@@ -44,78 +61,138 @@ class StudioTest(IsolatedAsyncioTestCase):
         langs_to_test = load_public_test_data()
         error_count = 0
 
-        async with async_playwright() as p:
-            browser = await p.chromium.launch(channel="chrome", headless=True)
-            page = await browser.new_page()
-            await page.goto("http://localhost:5000", wait_until="networkidle")
-            for test in langs_to_test:
+        # The current g2p-studio app leaks memory, so that if we try to run all the test
+        # cases in one single browser instance, a case (not always the same) eventually
+        # breaks. While that should get patched, for now, let's make unit testing
+        # reliable by running tests by blocks we know the app can handle.
+        block_size = 50
+
+        max_action_delay = 5000  # in ms - max time we'll wait for an action to work
+        polling_period = 20  # in ms - polling period for action effects
+
+        for block in range((len(langs_to_test) - 1) // block_size + 1):
+            LOGGER.info("Lauching async_playwright")
+            async with async_playwright() as p:
+                LOGGER.info("(Re)Launching browser")
+                browser = await p.chromium.launch(channel="chrome", headless=True)
+                LOGGER.info("Loading page")
+                page = await browser.new_page()
+                await page.goto(
+                    f"http://localhost:{self.port}", wait_until="networkidle"
+                )
+
                 # Define element locators
                 input_el = page.locator("#input")
                 output_el = page.locator("#output")
                 in_lang_selector = page.locator("#input-langselect")
                 out_lang_selector = page.locator("#output-langselect")
-                # Clear input and output
-                await input_el.fill("")
-                await output_el.fill("")
-                # Select input/output language
-                await in_lang_selector.select_option(value=test[0])
-                # wait up to 1 second for input lang to be set
-                # and for mappings to be populated
-                loop_time = 0
-                while loop_time <= 1000:
-                    input_lang = await in_lang_selector.input_value()
-                    if input_lang.strip() == test[0].strip():
-                        break
-                    await page.wait_for_timeout(100)
-                    loop_time += 100
-                await out_lang_selector.select_option(value=test[1])
-                # wait up to 1 second for output lang to be set
-                # and for mappings to be populated
-                loop_time = 0
-                while loop_time <= 1000:
-                    output_lang = await out_lang_selector.input_value()
-                    if output_lang.strip() == test[1].strip():
-                        break
-                    await page.wait_for_timeout(100)
-                    loop_time += 100
-                # Type fill input, then trigger rendering with keyup events
-                await input_el.fill(test[2])
-                await input_el.type(" ", delay=100)
-                await input_el.press("Backspace")
 
-                loop_time = 0
-                # wait up to 1 second for output to be populated
-                while loop_time <= 1000:
-                    output_text = await output_el.input_value()
-                    if output_text.strip() == test[3].strip():
-                        break
-                    await page.wait_for_timeout(100)
-                    loop_time += 100
-                # Check that output is correct
-                if not self.debug:
-                    self.assertEqual(output_text.strip(), test[3].strip())
+                for i, test in enumerate(
+                    langs_to_test[block_size * block : block_size * (block + 1)]
+                ):
                     LOGGER.info(
-                        f"Successfully converted {test[2]} from {test[0]} to {test[1]}"
+                        f"{i+block*block_size} {datetime.now()} "
+                        f"{test[0]}->{test[1]} {test[2]} -> {test[3]}"
                     )
-                elif output_text.strip() != test[3].strip():
-                    LOGGER.warning(
-                        f"test_langs.py: mapping error: {test[2]} from {test[0]} to {test[1]} should be {test[3]}, got {output_text}"
-                    )
-                    input_text = await input_el.input_value()
-                    if error_count == 0:
-                        test.append(input_text)
-                        test.append(output_text)
-                        first_failed_test = test
-                    error_count += 1
-                else:
-                    LOGGER.info(
-                        f"Successfully converted {test[2]} from {test[0]} to {test[1]}"
-                    )
+                    for attempt in range(1, 4):
+                        if attempt > 1:
+                            LOGGER.info(f"Attempt #{attempt}")
+                            await page.wait_for_timeout(1000)
+                        # Clear input and output
+                        await input_el.fill("")
+                        await output_el.fill("")
+                        output_text = ""
+
+                        # Select the input language
+                        await in_lang_selector.select_option(value=test[0])
+                        # wait up to max_action_delay ms for input lang to be set
+                        # and for mappings to be populated
+                        loop_time = 0
+                        while loop_time <= max_action_delay:
+                            input_lang = await in_lang_selector.input_value()
+                            if input_lang.strip() == test[0].strip():
+                                await page.wait_for_timeout(polling_period)
+                                break
+                            await page.wait_for_timeout(polling_period)
+                            loop_time += polling_period
+                        else:
+                            LOGGER.warning(
+                                f"Reached timeout setting in_lang for {test}"
+                            )
+                            continue
+
+                        # Select the output language
+                        await out_lang_selector.select_option(value=test[1])
+                        # wait up to max_action_delay ms for output lang to be set
+                        # and for mappings to be populated
+                        loop_time = 0
+                        while loop_time <= max_action_delay:
+                            output_lang = await out_lang_selector.input_value()
+                            if output_lang.strip() == test[1].strip():
+                                await page.wait_for_timeout(polling_period)
+                                break
+                            await page.wait_for_timeout(polling_period)
+                            loop_time += polling_period
+                        else:
+                            LOGGER.warning(
+                                f"Reached timeout setting out_lang for {test}"
+                            )
+                            continue
+
+                        # Type fill input, then trigger rendering with keyup events
+                        await input_el.fill(test[2])
+                        await input_el.type(" ", delay=100)
+                        await input_el.press("Backspace")
+
+                        loop_time = 0
+                        # wait up to max_action_delay ms for output to be populated
+                        while loop_time <= max_action_delay:
+                            output_text = await output_el.input_value()
+                            if output_text.strip() == test[3].strip():
+                                break
+                            await page.wait_for_timeout(polling_period)
+                            loop_time += polling_period
+                        else:
+                            LOGGER.warning(
+                                f"Reached timeout setting input text for {test}"
+                            )
+                            continue
+
+                        # We're done trying once an attempt succeeds
+                        if output_text.strip() == test[3].strip():
+                            break
+
+                    # Check that output is correct after the first succesful attempt or
+                    # after all the attempts have failed.
+                    if not self.debug:
+                        self.assertEqual(output_text.strip(), test[3].strip())
+                        LOGGER.info(
+                            f"Successfully converted {test[2]} from {test[0]} to {test[1]}"
+                        )
+                    elif output_text.strip() != test[3].strip():
+                        LOGGER.warning(
+                            f"test_langs.py: mapping error: {test[2]} from {test[0]} "
+                            f"to {test[1]} should be {test[3]}, got {output_text}"
+                        )
+                        input_text = await input_el.input_value()
+                        if error_count == 0:
+                            first_failed_test = [input_text, output_text]
+                        error_count += 1
+                    else:
+                        LOGGER.info(
+                            f"Successfully converted {test[2]} from {test[0]} to {test[1]}"
+                        )
+
+                # Let the user know we're closing the browser (by exiting the p context
+                # manager scope) to explain why there's a delay here.
+                LOGGER.info("Closing browser")
 
         if self.debug and error_count > 0:
             self.assertEqual(
-                first_failed_test[4],
-                first_failed_test[5],
+                first_failed_test[0],
+                first_failed_test[1],
+                f"{error_count} lang mapping test case(s) failed, "
+                "look for warnings in the logs above for details.",
             )
 
 

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -73,7 +73,7 @@ class StudioTest(IsolatedAsyncioTestCase):
         for block in range((len(langs_to_test) - 1) // block_size + 1):
             LOGGER.info("Lauching async_playwright")
             async with async_playwright() as p:
-                LOGGER.info("(Re)Launching browser")
+                LOGGER.info(("L" if block == 0 else "Rel") + "aunching browser")
                 browser = await p.chromium.launch(channel="chrome", headless=True)
                 LOGGER.info("Loading page")
                 page = await browser.new_page()
@@ -139,9 +139,9 @@ class StudioTest(IsolatedAsyncioTestCase):
                             )
                             continue
 
-                        # Type fill input, then trigger rendering with keyup events
-                        await input_el.fill(test[2])
-                        await input_el.type(" ", delay=100)
+                        # Type fill input, then trigger rendering with keyup event
+                        # optimization: make sure there is only 1 keyup event
+                        await input_el.fill(test[2] + " ")
                         await input_el.press("Backspace")
 
                         loop_time = 0

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -1,103 +1,123 @@
 #!/usr/bin/env python3
 import sys
 
-# this sucks, but IsolatedAsyncioTestCase doesn't work < 3.8
 # flake8: noqa: C901
-if sys.version_info >= (3, 8):
-    from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, main
 
-    from playwright.async_api import async_playwright
+from playwright.async_api import async_playwright
 
-    from g2p.app import APP, SOCKETIO
-    from g2p.log import LOGGER
-    from g2p.tests.public.data import load_public_test_data
+from g2p.app import APP, SOCKETIO
+from g2p.log import LOGGER
+from g2p.tests.public.data import load_public_test_data
 
-    class StudioTest(IsolatedAsyncioTestCase):
-        def setUp(self):
-            self.flask_test_client = APP.test_client()
-            self.socketio_test_client = SOCKETIO.test_client(
-                APP, flask_test_client=self.flask_test_client
-            )
-            self.debug = True
 
-        def test_socket_connection(self):
-            self.assertTrue(self.socketio_test_client.is_connected())
+class StudioTest(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.flask_test_client = APP.test_client()
+        self.socketio_test_client = SOCKETIO.test_client(
+            APP, flask_test_client=self.flask_test_client
+        )
+        self.debug = True
 
-        async def test_sanity(self):
-            async with async_playwright() as p:
-                browser = await p.chromium.launch(channel="chrome", headless=True)
-                page = await browser.new_page()
-                await page.goto("http://localhost:5000")
-                await page.wait_for_timeout(1000)
+    def test_socket_connection(self):
+        self.assertTrue(self.socketio_test_client.is_connected())
+
+    async def test_sanity(self):
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(channel="chrome", headless=True)
+            page = await browser.new_page()
+            await page.goto("http://localhost:5000")
+            await page.wait_for_timeout(1000)
+            input_el = page.locator("#input")
+            output_el = page.locator("#output")
+            await page.type("#input", "hello world")
+            await page.wait_for_timeout(1000)
+            input_text = await input_el.input_value()
+            output_text = await output_el.input_value()
+            self.assertEqual(input_text, output_text)
+            self.assertEqual(input_text, "hello world")
+            await input_el.fill("")
+            await output_el.fill("")
+
+    async def test_langs(self):
+
+        langs_to_test = load_public_test_data()
+        error_count = 0
+
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(channel="chrome", headless=True)
+            page = await browser.new_page()
+            await page.goto("http://localhost:5000", wait_until="networkidle")
+            for test in langs_to_test:
+                # Define element locators
                 input_el = page.locator("#input")
                 output_el = page.locator("#output")
-                await page.type("#input", "hello world")
-                await page.wait_for_timeout(1000)
-                input_text = await input_el.input_value()
-                output_text = await output_el.input_value()
-                self.assertEqual(input_text, output_text)
-                self.assertEqual(input_text, "hello world")
+                in_lang_selector = page.locator("#input-langselect")
+                out_lang_selector = page.locator("#output-langselect")
+                # Clear input and output
                 await input_el.fill("")
                 await output_el.fill("")
+                # Select input/output language
+                await in_lang_selector.select_option(value=test[0])
+                # wait up to 1 second for input lang to be set
+                # and for mappings to be populated
+                loop_time = 0
+                while loop_time <= 1000:
+                    input_lang = await in_lang_selector.input_value()
+                    if input_lang.strip() == test[0].strip():
+                        break
+                    await page.wait_for_timeout(100)
+                    loop_time += 100
+                await out_lang_selector.select_option(value=test[1])
+                # wait up to 1 second for output lang to be set
+                # and for mappings to be populated
+                loop_time = 0
+                while loop_time <= 1000:
+                    output_lang = await out_lang_selector.input_value()
+                    if output_lang.strip() == test[1].strip():
+                        break
+                    await page.wait_for_timeout(100)
+                    loop_time += 100
+                # Type fill input, then trigger rendering with keyup events
+                await input_el.fill(test[2])
+                await input_el.type(" ", delay=100)
+                await input_el.press("Backspace")
 
-        async def test_langs(self):
-
-            langs_to_test = load_public_test_data()
-            error_count = 0
-
-            async with async_playwright() as p:
-                browser = await p.chromium.launch(channel="chrome", headless=True)
-                page = await browser.new_page()
-                await page.goto("http://localhost:5000", wait_until="networkidle")
-                for test in langs_to_test:
-                    # Define element locators
-                    input_el = page.locator("#input")
-                    output_el = page.locator("#output")
-                    in_lang_selector = page.locator("#input-langselect")
-                    out_lang_selector = page.locator("#output-langselect")
-                    await input_el.fill("")
-                    await output_el.fill("")
-                    await in_lang_selector.select_option(value=test[0])
-                    await out_lang_selector.select_option(value=test[1])
-                    await input_el.fill(test[2])
-                    await input_el.type(" ", delay=100)
-
+                loop_time = 0
+                # wait up to 1 second for output to be populated
+                while loop_time <= 1000:
+                    output_text = await output_el.input_value()
+                    if output_text.strip() == test[3].strip():
+                        break
+                    await page.wait_for_timeout(100)
+                    loop_time += 100
+                # Check that output is correct
+                if not self.debug:
+                    self.assertEqual(output_text.strip(), test[3].strip())
+                    LOGGER.info(
+                        f"Successfully converted {test[2]} from {test[0]} to {test[1]}"
+                    )
+                elif output_text.strip() != test[3].strip():
+                    LOGGER.warning(
+                        f"test_langs.py: mapping error: {test[2]} from {test[0]} to {test[1]} should be {test[3]}, got {output_text}"
+                    )
                     input_text = await input_el.input_value()
-                    loop_time = 0
-                    # wait up to 1 second for output to be populated
-                    while loop_time <= 1000:
-                        output_text = await output_el.input_value()
-                        if output_text.strip() == test[3].strip():
-                            break
-                        await page.wait_for_timeout(100)
-                        loop_time += 100
-                    if not self.debug:
-                        self.assertEqual(output_text.strip(), test[3].strip())
-                        LOGGER.info(
-                            "Successfully converted {} from {} to {}".format(
-                                test[2], test[0], test[1]
-                            )
-                        )
-                    elif output_text.strip() != test[3].strip():
-                        LOGGER.warning(
-                            "test_langs.py: mapping error: {} from {} to {} should be {}, got {}".format(
-                                test[2], test[0], test[1], test[3], output_text
-                            )
-                        )
-                        if error_count == 0:
-                            test.append(input_text)
-                            test.append(output_text)
-                            first_failed_test = test
-                        error_count += 1
-                    else:
-                        LOGGER.info(
-                            "Successfully converted {} from {} to {}".format(
-                                test[2], test[0], test[1]
-                            )
-                        )
+                    if error_count == 0:
+                        test.append(input_text)
+                        test.append(output_text)
+                        first_failed_test = test
+                    error_count += 1
+                else:
+                    LOGGER.info(
+                        f"Successfully converted {test[2]} from {test[0]} to {test[1]}"
+                    )
 
-            if self.debug and error_count > 0:
-                self.assertEqual(
-                    first_failed_test[4],
-                    first_failed_test[5],
-                )
+        if self.debug and error_count > 0:
+            self.assertEqual(
+                first_failed_test[4],
+                first_failed_test[5],
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -1,16 +1,103 @@
 #!/usr/bin/env python3
+import sys
 
-from unittest import TestCase
+# this sucks, but IsolatedAsyncioTestCase doesn't work < 3.8
+# flake8: noqa: C901
+if sys.version_info >= (3, 8):
+    from unittest import IsolatedAsyncioTestCase
 
-from g2p.app import APP, SOCKETIO
+    from playwright.async_api import async_playwright
 
+    from g2p.app import APP, SOCKETIO
+    from g2p.log import LOGGER
+    from g2p.tests.public.data import load_public_test_data
 
-class StudioTest(TestCase):
-    def setUp(self):
-        self.flask_test_client = APP.test_client()
-        self.socketio_test_client = SOCKETIO.test_client(
-            APP, flask_test_client=self.flask_test_client
-        )
+    class StudioTest(IsolatedAsyncioTestCase):
+        def setUp(self):
+            self.flask_test_client = APP.test_client()
+            self.socketio_test_client = SOCKETIO.test_client(
+                APP, flask_test_client=self.flask_test_client
+            )
+            self.debug = True
 
-    def test_socket_connection(self):
-        self.assertTrue(self.socketio_test_client.is_connected())
+        def test_socket_connection(self):
+            self.assertTrue(self.socketio_test_client.is_connected())
+
+        async def test_sanity(self):
+            async with async_playwright() as p:
+                browser = await p.chromium.launch(channel="chrome", headless=True)
+                page = await browser.new_page()
+                await page.goto("http://localhost:5000")
+                await page.wait_for_timeout(1000)
+                input_el = page.locator("#input")
+                output_el = page.locator("#output")
+                await page.type("#input", "hello world")
+                await page.wait_for_timeout(1000)
+                input_text = await input_el.input_value()
+                output_text = await output_el.input_value()
+                self.assertEqual(input_text, output_text)
+                self.assertEqual(input_text, "hello world")
+                await input_el.fill("")
+                await output_el.fill("")
+
+        async def test_langs(self):
+
+            langs_to_test = load_public_test_data()
+            error_count = 0
+
+            async with async_playwright() as p:
+                browser = await p.chromium.launch(channel="chrome", headless=True)
+                page = await browser.new_page()
+                await page.goto("http://localhost:5000", wait_until="networkidle")
+                for test in langs_to_test:
+                    # Define element locators
+                    input_el = page.locator("#input")
+                    output_el = page.locator("#output")
+                    in_lang_selector = page.locator("#input-langselect")
+                    out_lang_selector = page.locator("#output-langselect")
+                    await input_el.fill("")
+                    await output_el.fill("")
+                    await in_lang_selector.select_option(value=test[0])
+                    await out_lang_selector.select_option(value=test[1])
+                    await input_el.fill(test[2])
+                    await input_el.type(" ", delay=100)
+
+                    input_text = await input_el.input_value()
+                    loop_time = 0
+                    # wait up to 1 second for output to be populated
+                    while loop_time <= 1000:
+                        output_text = await output_el.input_value()
+                        if output_text.strip() == test[3].strip():
+                            break
+                        await page.wait_for_timeout(100)
+                        loop_time += 100
+                    if not self.debug:
+                        self.assertEqual(output_text.strip(), test[3].strip())
+                        LOGGER.info(
+                            "Successfully converted {} from {} to {}".format(
+                                test[2], test[0], test[1]
+                            )
+                        )
+                    elif output_text.strip() != test[3].strip():
+                        LOGGER.warning(
+                            "test_langs.py: mapping error: {} from {} to {} should be {}, got {}".format(
+                                test[2], test[0], test[1], test[3], output_text
+                            )
+                        )
+                        if error_count == 0:
+                            test.append(input_text)
+                            test.append(output_text)
+                            first_failed_test = test
+                        error_count += 1
+                    else:
+                        LOGGER.info(
+                            "Successfully converted {} from {} to {}".format(
+                                test[2], test[0], test[1]
+                            )
+                        )
+
+            if self.debug and error_count > 0:
+                self.assertEqual(
+                    first_failed_test[4],
+                    first_failed_test[5],
+                )

--- a/requirements/requirements.test.txt
+++ b/requirements/requirements.test.txt
@@ -1,0 +1,1 @@
+playwright>=1.26.1

--- a/run_studio.py
+++ b/run_studio.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 
 from g2p.app import APP, SOCKETIO
+from g2p.log import LOGGER
 
-SOCKETIO.run(APP, host="0.0.0.0", port=5000, debug=True)
+host = "0.0.0.0"
+port = 5000
+LOGGER.info(f"g2p-studio listening on http://{host}:{port}")
+
+SOCKETIO.run(APP, host=host, port=port, debug=True)


### PR DESCRIPTION
Hey Eric,

This is the PR that will fix https://github.com/roedoejet/g2p/issues/188 among a variety of other undiagnosed issues with haa, mic, tli, ctp, and crk

Basically:

- E2E tests are added for studio that run separately (as they require 3.8)
- G2P Studio was out of date with respect to the `rule_ordering` api
- The "reverse" checkbox should not be checked by default in studio, even if it is in the mapping declaration, because mappings are already reversed when they are sent to the Studio
- We actually had a more general bug in g2p - abbreviations which reference other abbreviations (for example defining `VOWELS` as being comprised of `HIGH_VOWELS` and `LOW_VOWELS` abbreviations was broken. This fixes that by recursively expanding abbreviations (with a fail-safe for self-referential infinite recursion errors)
- `prevent_feeding` on individual rules was not working properly because that information was lost when sent to studio. that is now fixed.

Since Studio builds from `master` I'm thinking either we should change it to build from `release` or we should run this tests on every push to `master`.

Thanks!

P.S After this, let's definitely make a release