### PR TITLE
ci: bump CI actions to current to heed GitHub warnings

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -9,9 +9,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           coverage run run_tests.py dev
           coverage xml
           if git status | grep -E 'static.*json|mapping.*pkl'; then echo 'g2p databases out of date, please run "g2p update" and commit the results.'; false; else echo OK; fi
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true # optional (default = false)
 


### PR DESCRIPTION
Fixed:
 - actions/codecov-action: bump to v4 uses node16 instead of the deprecated node12
 - actions/setup-python: v4 fixes warnings about set-output and save-state being deprecated
 - actions/checkout: v3 uses node16 instead of the deprecated node12

Issues not fixed yet, all in `pythonpublish.yml` workflow:
 - Out "Determine tag" code gets this warning: Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
 - mathieudutour/github-tag-action@v5.5 gets the set-output warning and the node12 warning. Update to @v6? https://github.com/mathieudutour/github-tag-action also says to use ncipollo/release-action@v1 instead of actions/create-release
 - actions/create-release is obsolete and not longer maintained: https://github.com/actions/create-release01 use ncipollo/release-action instead?

We'll probably need to use the test PyPI server to test potential patches to these problems.
