### PR TITLE
ci: g2p codecov action does not use dir

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,6 @@ jobs:
           if git status | grep -E 'static.*json|mapping.*pkl'; then echo 'g2p databases out of date, please run "g2p update" and commit the results.'; false; else echo OK; fi
       - uses: codecov/codecov-action@v3
         with:
-          directory: ./test
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false # too many upload errors to keep "true"
 


### PR DESCRIPTION
Quick fix, that `dir:` was from Studio but in g2p the coverage file is in `.` and we don't need to specify it.