### PR TITLE
Misc improvements to the g2p-studio static app

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # #no-ci in the commit log flags commit we don't want CI-validated
     if: ${{ !contains(github.event.head_commit.message, '#no-ci') }}
     steps:

--- a/g2p/static/custom.css
+++ b/g2p/static/custom.css
@@ -44,6 +44,12 @@ h4 {
     display: inline;
 }
 
+/* Pad the bottom of the page, otherwise it looks like you can't see the bottom
+ * of the abbreviations table. */
+.container {
+    padding-bottom: 40px;
+}
+
 table td {
     text-align: center;
     padding: 3px !important;

--- a/g2p/static/custom.css
+++ b/g2p/static/custom.css
@@ -32,6 +32,10 @@ h4 {
     margin-top: 40px;
 }
 
+.mg-bot {
+    margin-bottom: 40px;
+}
+
 .hot-container,
 .settings,
 .abbs-container {
@@ -42,12 +46,6 @@ h4 {
 .settings.active,
 .abbs-container.active {
     display: inline;
-}
-
-/* Pad the bottom of the page, otherwise it looks like you can't see the bottom
- * of the abbreviations table. */
-.container {
-    padding-bottom: 40px;
 }
 
 table td {

--- a/g2p/static/custom.js
+++ b/g2p/static/custom.js
@@ -187,7 +187,7 @@ function createAbbs(index, data) {
         height: 287,
         maxRows: 150,
         rowHeaders: true,
-        colHeaders: true,
+        colHeaders: ["Abbreviation Name"],
         afterRowMove: (rows, target) => {
             convert()
         },
@@ -286,12 +286,6 @@ createTable(0, dataObject)
 createAbbs(0, varsObject)
 createSettings(0, settingsObject)
 
-document.getElementById("export-abbs").addEventListener("click", function(event) {
-    varhot.getPlugin("exportFile").downloadFile("csv", { filename: "abbreviations" });
-})
-
-// Kwargs
-
 document.getElementById('standard-radio').addEventListener('click', function(event) {
     if ($('#standard').is(":hidden")) {
         $('#input').val($('#indexInput').val())
@@ -319,8 +313,9 @@ getIncludedMappings = function() {
 
         for (index of indices) {
             mapping = {}
-            mapping['mapping'] = TABLES[index].getSourceData()
-            mapping['abbreviations'] = ABBS[index].getData()
+            // Extract only non-empty rules and abbreviations for processing
+            mapping['mapping'] = TABLES[index].getSourceData().filter(v => v.in)
+            mapping['abbreviations'] = ABBS[index].getData().filter(v => v[0])
             mapping['kwargs'] = getKwargs(index)
             mappings.push(mapping)
         }
@@ -542,11 +537,13 @@ $('#varhot-add-row').click(function(event) {
 $('#export-abbs').click(function(event) {
     let active = $('li.title.abbs.active')
     let index = $('li.title.abbs').index(active)
-    ABBS[index].getPlugin("exportFile").downloadFile("csv", { filename: "rules" });
+    // TODO: filter out lines where the first column (i.e., the abbreviation name) is empty
+    ABBS[index].getPlugin("exportFile").downloadFile("csv", { filename: "abbreviations" });
 })
 $('#export-rules').click(function(event) {
     let active = $('li.title.rules.active')
     let index = $('li.title.rules').index(active)
+    // TODO: filter out lines where .in is empty
     TABLES[index].getPlugin("exportFile").downloadFile("csv", { filename: "rules" });
 })
 $('#langselect').change(function() {

--- a/g2p/templates/index.html
+++ b/g2p/templates/index.html
@@ -139,7 +139,7 @@
                 </div>
             </div>
         </div>
-        <div class='row mg-top'>
+        <div class='row mg-top mg-bot'>
             <div class='columns twelve'>
                 <h4>Custom Abbreviations</h4>
                 <p>Follow the example below to create your own abbreviations to use in your rules.</p>


### PR DESCRIPTION
 - add padding at the very bottom, otherwise it looks like you can't scroll to the end of the abbreviations table
 - have `convert()` send only non-empty rules and abbreviations to the server, since they just case lots of spurious warnings, and the empty lines in g2p-studio are there to facilitate insert rules, they're not meant to actually be empty rules
 - label the first column of the abbreviations table "Abbreviation Name"
 - remove the dead `"export-abbs"` listener that depended on the `varhot` variable which got removed a while ago (we now use `$('#export-abbs').click(...)` instead).

Still TODO because I could not figure it out: when you click on EXPORT for either Custom Rules or Custom Abbreviations, rules with an empty `.in` and abbreviations with an empty name should be filtered out too, before the `.csv` files are generated and downloaded.