### PR TITLE
chore(deps): we are compat with networkx up to 2.8.4

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,7 @@ Flask>=2.0.0
 flask_socketio==4.3.2
 flask-talisman>=0.7.0
 flask-restful>=0.3.9
-networkx==2.5
+networkx>=2.5,<=2.8.4
 panphon>=0.19
 python-engineio==3.14.2 
 python-socketio==4.6.1


### PR DESCRIPTION
Tested various versions of networkx to establish compatibility with g2p:
 - Python 3.6, which we still support, only has 2.5 and 2.5.1, so >= 2.5 is needed
 - networkx 3.0 has a different API than 2.x, so if we were to adopt it, we'd need to modify our code, but then we'd lose support for Python < 3.8, so we don't want to do that now, and we won't want to do it for a while.
 - networkx 2.8.5+ work fine, except that the exact contents of g2p/mappings/langs/network.pkl end up slightly different, so then we'd conclude `g2p update` has to be run again, even though the langs DB had not changed.

Thus, I end up with `networkx>=2.5,<=2.8.4`.
What actually happens at the moment of committing:
 - Python 3.6: networkx 2.5.1
 - Python 3.7: networkx 2.6.3
 - Python 3.8-3.10: networkx 2.8.4
 - Python 3.11: networkx 2.8.4 too, even though the documentations says it does not support 3.11 (https://networkx.org/documentation/stable/release/release_2.8.4.html) 3.8.8 is the first version say declare compatibility with Python 3.11. Unit tests pass with Python 3.11 + networkx 2.8.4, though, so things look fine.

