### PR TITLE
Fix for Arabic text

### DIFF
--- a/g2p/tests/test_unidecode_transducer.py
+++ b/g2p/tests/test_unidecode_transducer.py
@@ -41,6 +41,16 @@ class UnidecodeTransducerTest(TestCase):
             tg.output_string, "EY T EY  N UW N AA V UW T  N OW N AA F OW T "
         )
 
+    def test_unidecode_arabic_to_arpabet(self):
+        transducer = make_g2p("und", "eng-arpabet")
+        tg = transducer("السلام عليكم")
+        self.assertEqual(tg.output_string, "L S L M L Y K M ")
+
+    def test_unidecode_arabic_presentation_to_arpabet(self):
+        transducer = make_g2p("und", "eng-arpabet")
+        tg = transducer("ﺷﻜﺮﺍﹰ")
+        self.assertEqual(tg.output_string, "S HH K D ")
+
 
 if __name__ == "__main__":
     main()

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -8,6 +8,7 @@ import copy
 import re
 from collections import defaultdict
 from typing import Dict, List
+import unicodedata
 
 import text_unidecode
 
@@ -522,7 +523,9 @@ class Transducer:
         tg = TransductionGraph(to_convert)
 
         # Conversion is done character by character using unidecode
-        converted = [text_unidecode.unidecode(c) for c in to_convert]
+        converted = [unicodedata.normalize("NFKC", c) for c in to_convert]
+        converted = [text_unidecode.unidecode(c) for c in converted]
+        converted = [c if c.isalpha() else "" for c in converted]
         tg.output_string = "".join(converted)
 
         # Edges are calculated to follow the conversion step by step
@@ -671,7 +674,6 @@ class Transducer:
         tg.edges.sort(key=lambda x: x[0])
         for i, edge in enumerate(tg.edges):
             if edge[1] is None:
-
                 # if previous exists, use that, otherwise use following, otherwise None
                 previous = [x for x in tg.edges[:i] if x[1] is not None]
                 try:


### PR DESCRIPTION
There were two errors caused by Arabic text, leading to 422 and 500 errors in Studio Web when certain Arabic words were pasted in.

(1) Letters in presentation forms (e.g. U+FEB7 ARABIC LETTER SHEEN INITIAL FORM) isn't understood by text-unidecode.  Getting rid of the positional information requires a K normalization, like NFKC.

(2) If text-unidecode turns a character to a non-alpha character, this causes trouble downstream.  Many Arabic letters result in non-alpha characters.  We used to strip these out, but this got lost in the port from Studio to G2P.  I've added it back in.

Pull request template for adding a new language
-----------------------------------------------

*Do not use this for other types of pull requests*

* **Please check if the PR fulfills these requirements**
- [ ] Mapping files are added in `g2p/mappings/langs`
- [ ] Mapping is either added to an existing folder or a new folder has been added
- [ ] Language folder and files use appropriate [ISO 639-3 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-3_codes)
- [ ] Config.yaml file includes all author names, and settings necessary
- [ ] Please add some test data in `g2p/tests/public/data`. The added file should be a csv/tsv/psv file and each row should have the format `[input_mapping_code,output_mapping_code,input_string,output_string]`
- [ ] As the last step, G2P has been updated by running `g2p update` locally and committing the change
- [ ] You agree to license your contribution under the same license as this project (see [LICENSE](https://github.com/roedoejet/g2p/blob/master/LICENSE) file).

* **Other information**:
