### PR TITLE
Dev.kanji fix

### DIFF
--- a/g2p/tests/test_unidecode_transducer.py
+++ b/g2p/tests/test_unidecode_transducer.py
@@ -49,7 +49,12 @@ class UnidecodeTransducerTest(TestCase):
     def test_unidecode_arabic_presentation_to_arpabet(self):
         transducer = make_g2p("und", "eng-arpabet")
         tg = transducer("ﺷﻜﺮﺍﹰ")
-        self.assertEqual(tg.output_string, "S HH K D ")
+        self.assertEqual(tg.output_string, "S HH K D  AA N ")
+
+    def test_unidecode_kanji_to_arpabet(self):
+        transducer = make_g2p("und", "eng-arpabet")
+        tg = transducer("日本語")
+        self.assertEqual(tg.output_string, "D IY  B EY N  Y UW  ")
 
 
 if __name__ == "__main__":

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -42,6 +42,8 @@ Index = Dict
 # [[0,1],[2,-1]]
 ChangeLog = List[List[int]]
 
+UNIDECODE_SPECIALS = ["@", "?", "'", ",", ":", " "]
+
 
 class TransductionGraph:
     """This is the object returned after performing a transduction using a Transducer.
@@ -525,7 +527,9 @@ class Transducer:
         # Conversion is done character by character using unidecode
         converted = [unicodedata.normalize("NFKC", c) for c in to_convert]
         converted = [text_unidecode.unidecode(c) for c in converted]
-        converted = [c if c.isalpha() or c == " " else "" for c in converted]
+        converted = [
+            c if c.isalpha() or c in UNIDECODE_SPECIALS else "" for c in converted
+        ]
         tg.output_string = "".join(converted)
 
         # Edges are calculated to follow the conversion step by step

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -45,6 +45,10 @@ ChangeLog = List[List[int]]
 UNIDECODE_SPECIALS = ["@", "?", "'", ",", ":", " "]
 
 
+def sanitize_unidecode_output(s: str) -> bool:
+    return "".join(c if c.isalpha() or c in UNIDECODE_SPECIALS else "" for c in s)
+
+
 class TransductionGraph:
     """This is the object returned after performing a transduction using a Transducer.
 
@@ -527,9 +531,7 @@ class Transducer:
         # Conversion is done character by character using unidecode
         converted = [unicodedata.normalize("NFKC", c) for c in to_convert]
         converted = [text_unidecode.unidecode(c) for c in converted]
-        converted = [
-            c if c.isalpha() or c in UNIDECODE_SPECIALS else "" for c in converted
-        ]
+        converted = [sanitize_unidecode_output(c) for c in converted]
         tg.output_string = "".join(converted)
 
         # Edges are calculated to follow the conversion step by step


### PR DESCRIPTION
A fix to the handling of Han/Kanji characters in unidecode.  The unidecode sanitizer that handles non-alphabetic Perso-Arabic unidecode outputs was too aggressive in identifying some strings as "non-alphabetic", which ended up throwing out Han/Kanji outputs because they contain a trailing space.