### PR TITLE
Fix to Han/Kanji characters in Und

### DIFF
--- a/g2p/tests/test_unidecode_transducer.py
+++ b/g2p/tests/test_unidecode_transducer.py
@@ -49,8 +49,12 @@ class UnidecodeTransducerTest(TestCase):
     def test_unidecode_arabic_presentation_to_arpabet(self):
         transducer = make_g2p("und", "eng-arpabet")
         tg = transducer("ﺷﻜﺮﺍﹰ")
-        self.assertEqual(tg.output_string, "S HH K D ")
+        self.assertEqual(tg.output_string, "S HH K D  AA N ")
 
+    def test_unidecode_kanji_to_arpabet(self):
+        transducer = make_g2p("und", "eng-arpabet")
+        tg = transducer("日本語")
+        self.assertEqual(tg.output_string, "D IY  B EY N  Y UW  ")
 
 if __name__ == "__main__":
     main()

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -44,6 +44,8 @@ ChangeLog = List[List[int]]
 
 UNIDECODE_SPECIALS = ["@", "?", "'", ",", ":", " "]
 
+def sanitize_unidecode_output(s: str) -> bool:
+    return "".join(c if c.isalpha() or c in UNIDECODE_SPECIALS else "" for c in s)
 
 class TransductionGraph:
     """This is the object returned after performing a transduction using a Transducer.
@@ -529,9 +531,7 @@ class Transducer:
             text_unidecode.unidecode(unicodedata.normalize("NFKC", c))
             for c in to_convert
         ]
-        converted = [
-            c if c.isalpha() or c in UNIDECODE_SPECIALS else "" for c in converted
-        ]
+        converted = [sanitize_unidecode_output(c) for c in converted]
         tg.output_string = "".join(converted)
 
         # Edges are calculated to follow the conversion step by step


### PR DESCRIPTION
Fixes to how we sanitize unidecode outputs so that we don't inadvertently throw out the outputs of Han/Kanji unidecoding.  Same changes as the last commit, but on a clean branch.