### PR TITLE
fix: update requirements.txt for python 3.6

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,9 @@ flask-talisman>=0.7.0
 flask-restful>=0.3.9
 networkx==2.5
 panphon>=0.19
-python-engineio==3.14.2 
+editdistance==0.6.1
+numpy==1.19.5
+python-engineio==3.14.2
 python-socketio==4.6.1
 pyyaml>=5.2
 regex


### PR DESCRIPTION
The Numpy version is incompatible with panphon but seems to install anyway (more recent versions demanded by panphon are not available for 3.6).  editdistance 0.6.2 won't compile properly so back it off to 0.6.1

I was worried about playwright not working on 3.6 but I see that we use 3.8 to run that test in any case.