### PR TITLE
Improvements to Transducer API

### DIFF
--- a/g2p/api.py
+++ b/g2p/api.py
@@ -124,7 +124,9 @@ class Text(Resource):
             text = tg.output_string
             input_text = tg.input_string
             debugger = tg.debugger if debugger else debugger
-            index = tg.edges if index else index
+            # Preserve old behaviour of incompatible TransductionGraph
+            # and CompositeTransductionGraph outputs
+            index = tg._edges if index else index
             return {
                 "input-text": input_text,
                 "output-text": text,

--- a/g2p/api.py
+++ b/g2p/api.py
@@ -124,9 +124,7 @@ class Text(Resource):
             text = tg.output_string
             input_text = tg.input_string
             debugger = tg.debugger if debugger else debugger
-            # Preserve old behaviour of incompatible TransductionGraph
-            # and CompositeTransductionGraph outputs
-            index = tg._edges if index else index
+            index = tg.edges if index else index
             return {
                 "input-text": input_text,
                 "output-text": text,

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -429,6 +429,13 @@ def generate_mapping(  # noqa: C901
 
 
 @click.option(
+    "--substring-alignments",
+    "-a",
+    default=False,
+    is_flag=True,
+    help="Show the minimal monotonic substring alignments.",
+)
+@click.option(
     "--pretty-edges",
     "-e",
     default=False,
@@ -489,6 +496,7 @@ def convert(  # noqa: C901
     pretty_edges,
     tok_lang,
     config,
+    substring_alignments,
 ):
     """Convert INPUT_TEXT through g2p mapping(s) from IN_LANG to OUT_LANG.
 
@@ -556,6 +564,8 @@ def convert(  # noqa: C901
     if check:
         transducer.check(tg, display_warnings=True)
     outputs = [tg.output_string]
+    if substring_alignments:
+        outputs += [tg.substring_alignments()]
     if pretty_edges:
         outputs += [tg.pretty_edges()]
     if debugger:

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -559,7 +559,7 @@ def convert(  # noqa: C901
     if pretty_edges:
         outputs += [tg.pretty_edges()]
     if debugger:
-        outputs += [tg.edges, tg.debugger]
+        outputs += [tg._edges, tg.debugger]
     if len(outputs) > 1:
         click.echo(pprint.pformat(outputs, indent=4))
     else:

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -559,7 +559,7 @@ def convert(  # noqa: C901
     if pretty_edges:
         outputs += [tg.pretty_edges()]
     if debugger:
-        outputs += [tg._edges, tg.debugger]
+        outputs += [tg.edges, tg.debugger]
     if len(outputs) > 1:
         click.echo(pprint.pformat(outputs, indent=4))
     else:

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -194,6 +194,12 @@ class CliTest(TestCase):
         mapped_lower = "s"
         self.assertNotIn(mapped_lower, returned_set)
 
+    def test_convert_option_a(self):
+        result = self.runner.invoke(convert, "-a hello eng eng-arpabet")
+        self.assertIn(
+            "[('h', 'HH '), ('e', 'AH '), ('ll', 'L '), ('o', 'OW ')]", result.stdout
+        )
+
     def test_convert_option_e(self):
         result = self.runner.invoke(convert, "-e est fra eng-arpabet")
         for s in [

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -197,9 +197,9 @@ class CliTest(TestCase):
     def test_convert_option_e(self):
         result = self.runner.invoke(convert, "-e est fra eng-arpabet")
         for s in [
-            "[['e', 'ɛ'], ['s', 'ɛ'], ['t', 'ɛ']]",
-            "[['ɛ', 'ɛ']]",
-            "[['ɛ', 'E'], ['ɛ', 'H'], ['ɛ', ' ']]",
+            "[('e', 'ɛ'), ('s', 'ɛ'), ('t', 'ɛ')]",
+            "[('ɛ', 'ɛ')]",
+            "[('ɛ', 'E'), ('ɛ', 'H'), ('ɛ', ' ')]",
         ]:
             self.assertIn(s, result.stdout)
 

--- a/g2p/tests/test_indices.py
+++ b/g2p/tests/test_indices.py
@@ -280,15 +280,21 @@ class IndicesTest(TestCase):
         transducer_1 = self.trans_feeding_1("ab")
         self.assertEqual(transducer_1.output_string, "cd")
         self.assertEqual(transducer_1.edges, [(0, 0), (0, 1), (1, 0), (1, 1)])
+        # because of "crossed" indices, we get one single monotonic alignment
+        self.assertEqual(transducer_1.alignments(), [("ab", "cd")])
         transducer_2 = self.trans_feeding_2("a")
         self.assertEqual(transducer_2.output_string, "b")
         self.assertEqual(transducer_2.edges, [(0, 0)])
+        self.assertEqual(transducer_2.alignments(), [("a", "b")])
 
     def test_issue_157(self):
         """Test explicit problem from Issue 157"""
         transducer = self.trans_157("abcmn")
         self.assertEqual(transducer.output_string, "deNM")
         self.assertEqual(transducer.edges, [(0, 0), (1, 1), (2, 1), (3, 3), (4, 2)])
+        self.assertEqual(
+            transducer.alignments(), [("a", "d"), ("bc", "e"), ("mn", "NM")]
+        )
 
     def test_issue_173(self):
         """Test explicit problems from Issue 173"""
@@ -305,11 +311,29 @@ class IndicesTest(TestCase):
             [(0, 1), (1, 0), (2, 0), (3, 2), (4, 3), (5, 4), (6, 5), (7, 6)],
         )
         self.assertEqual(
+            transducer_1.alignments(),
+            [("xyz", "ab"), ("m", "m"), ("n", "n"), ("d", "d"), ("e", "e"), ("f", "f")],
+        )
+        self.assertEqual(
             transducer_2.edges,
             [(0, 0), (1, 1), (2, 1), (3, 2), (4, 3), (5, 4), (6, 5), (7, 6)],
         )
+        self.assertEqual(
+            transducer_2.alignments(),
+            [
+                ("x", "a"),
+                ("yz", "b"),
+                ("m", "m"),
+                ("n", "n"),
+                ("d", "d"),
+                ("e", "e"),
+                ("f", "f"),
+            ],
+        )
         self.assertEqual(transducer_3.edges, [(0, 0), (1, 0), (2, 1)])
+        self.assertEqual(transducer_3.alignments(), [("ab", "X"), ("c", "Y")])
         self.assertEqual(transducer_4.edges, [(0, 0), (0, 1), (1, 2), (2, 2)])
+        self.assertEqual(transducer_4.alignments(), [("a", "xy"), ("bc", "z")])
 
     def test_explicit_equal(self):
         """Test synonymous syntax for explicit indices"""

--- a/g2p/tests/test_indices.py
+++ b/g2p/tests/test_indices.py
@@ -423,6 +423,10 @@ class IndicesTest(TestCase):
             transducer.substring_alignments(),
             [("t", "p"), ("e", "e"), ("s", "s"), ("t", "t")],
         )
+        transducer = self.trans_one("")
+        self.assertEqual(transducer.output_string, "")
+        self.assertEqual(transducer.edges, [])
+        self.assertEqual(transducer.substring_alignments(), [])
 
     def test_case_two(self):
         transducer = self.trans_two("test")

--- a/g2p/tests/test_indices.py
+++ b/g2p/tests/test_indices.py
@@ -286,11 +286,11 @@ class IndicesTest(TestCase):
         self.assertEqual(transducer_1.output_string, "cd")
         self.assertEqual(transducer_1.edges, [(0, 0), (0, 1), (1, 0), (1, 1)])
         # because of "crossed" indices, we get one single monotonic alignment
-        self.assertEqual(transducer_1.alignments(), [("ab", "cd")])
+        self.assertEqual(transducer_1.substring_alignments(), [("ab", "cd")])
         transducer_2 = self.trans_feeding_2("a")
         self.assertEqual(transducer_2.output_string, "b")
         self.assertEqual(transducer_2.edges, [(0, 0)])
-        self.assertEqual(transducer_2.alignments(), [("a", "b")])
+        self.assertEqual(transducer_2.substring_alignments(), [("a", "b")])
 
     def test_issue_157(self):
         """Test explicit problem from Issue 157"""
@@ -298,7 +298,7 @@ class IndicesTest(TestCase):
         self.assertEqual(transducer.output_string, "deNM")
         self.assertEqual(transducer.edges, [(0, 0), (1, 1), (2, 1), (3, 3), (4, 2)])
         self.assertEqual(
-            transducer.alignments(), [("a", "d"), ("bc", "e"), ("mn", "NM")]
+            transducer.substring_alignments(), [("a", "d"), ("bc", "e"), ("mn", "NM")]
         )
 
     def test_issue_173(self):
@@ -316,7 +316,7 @@ class IndicesTest(TestCase):
             [(0, 1), (1, 0), (2, 0), (3, 2), (4, 3), (5, 4), (6, 5), (7, 6)],
         )
         self.assertEqual(
-            transducer_1.alignments(),
+            transducer_1.substring_alignments(),
             [("xyz", "ab"), ("m", "m"), ("n", "n"), ("d", "d"), ("e", "e"), ("f", "f")],
         )
         self.assertEqual(
@@ -324,7 +324,7 @@ class IndicesTest(TestCase):
             [(0, 0), (1, 1), (2, 1), (3, 2), (4, 3), (5, 4), (6, 5), (7, 6)],
         )
         self.assertEqual(
-            transducer_2.alignments(),
+            transducer_2.substring_alignments(),
             [
                 ("x", "a"),
                 ("yz", "b"),
@@ -336,9 +336,11 @@ class IndicesTest(TestCase):
             ],
         )
         self.assertEqual(transducer_3.edges, [(0, 0), (1, 0), (2, 1)])
-        self.assertEqual(transducer_3.alignments(), [("ab", "X"), ("c", "Y")])
+        self.assertEqual(transducer_3.substring_alignments(), [("ab", "X"), ("c", "Y")])
         self.assertEqual(transducer_4.edges, [(0, 0), (0, 1), (1, 2), (2, 2)])
-        self.assertEqual(transducer_4.alignments(), [("a", "xy"), ("bc", "z")])
+        self.assertEqual(
+            transducer_4.substring_alignments(), [("a", "xy"), ("bc", "z")]
+        )
 
     def test_explicit_equal(self):
         """Test synonymous syntax for explicit indices"""
@@ -375,13 +377,14 @@ class IndicesTest(TestCase):
         self.assertEqual(
             transducer_lite.edges, [(0, 4), (1, 0), (2, 1), (2, 2), (3, 3)]
         )
-        self.assertEqual(transducer_lite.alignments(), [("abcc", "ccccc")])
+        self.assertEqual(transducer_lite.substring_alignments(), [("abcc", "ccccc")])
         self.assertEqual(
             transducer_lite_extra.edges,
             [(0, 4), (1, 0), (2, 1), (2, 2), (3, 3), (4, 5)],
         )
         self.assertEqual(
-            transducer_lite_extra.alignments(), [("abcc", "ccccc"), ("a", "a")]
+            transducer_lite_extra.substring_alignments(),
+            [("abcc", "ccccc"), ("a", "a")],
         )
         transducer_no_i = self.trans_wacky("\U0001f600\U0001f603\U0001f604\U0001f604")
         self.assertEqual(
@@ -395,7 +398,7 @@ class IndicesTest(TestCase):
         )
         self.assertEqual(transducer.edges, [(0, 4), (1, 0), (2, 1), (2, 2), (3, 3)])
         self.assertEqual(
-            transducer.alignments(),
+            transducer.substring_alignments(),
             [
                 (
                     "\U0001f600\U0001f603\U0001f604\U0001f604",
@@ -409,7 +412,7 @@ class IndicesTest(TestCase):
         transducer = self.trans_circum("ac")
         self.assertEqual(transducer.output_string, "cac")
         self.assertEqual(transducer.edges, [(0, 1), (1, 0), (1, 2)])
-        self.assertEqual(transducer.alignments(), [("ac", "cac")])
+        self.assertEqual(transducer.substring_alignments(), [("ac", "cac")])
 
     def test_case_one(self):
         """Test case one"""
@@ -417,35 +420,41 @@ class IndicesTest(TestCase):
         self.assertEqual(transducer.output_string, "pest")
         self.assertEqual(transducer.edges, [(0, 0), (1, 1), (2, 2), (3, 3)])
         self.assertEqual(
-            transducer.alignments(), [("t", "p"), ("e", "e"), ("s", "s"), ("t", "t")]
+            transducer.substring_alignments(),
+            [("t", "p"), ("e", "e"), ("s", "s"), ("t", "t")],
         )
 
     def test_case_two(self):
         transducer = self.trans_two("test")
         self.assertEqual(transducer.output_string, "tst")
         self.assertEqual(transducer.edges, [(0, 0), (1, 0), (2, 1), (3, 2)])
-        self.assertEqual(transducer.alignments(), [("te", "t"), ("s", "s"), ("t", "t")])
+        self.assertEqual(
+            transducer.substring_alignments(), [("te", "t"), ("s", "s"), ("t", "t")]
+        )
 
     def test_case_three(self):
         transducer = self.trans_three("test")
         self.assertEqual(transducer.output_string, "chest")
         self.assertEqual(transducer.edges, [(0, 0), (0, 1), (1, 2), (2, 3), (3, 4)])
         self.assertEqual(
-            transducer.alignments(), [("t", "ch"), ("e", "e"), ("s", "s"), ("t", "t")]
+            transducer.substring_alignments(),
+            [("t", "ch"), ("e", "e"), ("s", "s"), ("t", "t")],
         )
 
     def test_case_four(self):
         transducer = self.trans_four("test")
         self.assertEqual(transducer.output_string, "pst")
         self.assertEqual(transducer.edges, [(0, 0), (1, 0), (2, 1), (3, 2)])
-        self.assertEqual(transducer.alignments(), [("te", "p"), ("s", "s"), ("t", "t")])
+        self.assertEqual(
+            transducer.substring_alignments(), [("te", "p"), ("s", "s"), ("t", "t")]
+        )
 
     def test_case_six(self):
         transducer = self.trans_six("test")
         self.assertEqual(transducer.output_string, "tset")
         self.assertEqual(transducer.edges, [(0, 0), (1, 2), (2, 1), (3, 3)])
         self.assertEqual(
-            transducer.alignments(), [("t", "t"), ("es", "se"), ("t", "t")]
+            transducer.substring_alignments(), [("t", "t"), ("es", "se"), ("t", "t")]
         )
 
     def test_case_long_six(self):
@@ -453,7 +462,7 @@ class IndicesTest(TestCase):
         self.assertEqual(transducer.output_string, "sesese")
         # Ensure that *minimal* monotonic segments are output
         self.assertEqual(
-            transducer.alignments(),
+            transducer.substring_alignments(),
             [("es", "se"), ("es", "se"), ("s", "s"), ("e", "e")],
         )
 
@@ -462,14 +471,15 @@ class IndicesTest(TestCase):
         self.assertEqual(transducer_as_written.output_string, "test")
         self.assertEqual(transducer_as_written.edges, [(0, 0), (1, 1), (2, 2), (3, 3)])
         self.assertEqual(
-            transducer_as_written.alignments(),
+            transducer_as_written.substring_alignments(),
             [("t", "t"), ("e", "e"), ("s", "s"), ("t", "t")],
         )
         transducer = self.trans_seven("test")
         self.assertEqual(transducer.output_string, "tesht")
         self.assertEqual(transducer.edges, [(0, 0), (1, 1), (2, 2), (2, 3), (3, 4)])
         self.assertEqual(
-            transducer.alignments(), [("t", "t"), ("e", "e"), ("s", "sh"), ("t", "t")]
+            transducer.substring_alignments(),
+            [("t", "t"), ("e", "e"), ("s", "sh"), ("t", "t")],
         )
 
     def test_case_eight(self):
@@ -477,27 +487,28 @@ class IndicesTest(TestCase):
         self.assertEqual(transducer.output_string, "chess")
         self.assertEqual(transducer.edges, [(0, 0), (1, 1), (1, 2), (2, 3), (3, 4)])
         self.assertEqual(
-            transducer.alignments(), [("t", "c"), ("e", "he"), ("s", "s"), ("t", "s")]
+            transducer.substring_alignments(),
+            [("t", "c"), ("e", "he"), ("s", "s"), ("t", "s")],
         )
 
     def test_case_nine(self):
         transducer = self.trans_nine("aa")
         self.assertEqual(transducer.output_string, "")
         self.assertEqual(transducer.edges, [(0, None), (1, None)])
-        # Support deletions in alignments
-        self.assertEqual(transducer.alignments(), [("aa", "")])
+        # Support deletions in substring_alignments
+        self.assertEqual(transducer.substring_alignments(), [("aa", "")])
 
     def test_case_ten(self):
         transducer = self.trans_ten("abc")
         self.assertEqual(transducer.output_string, "a")
         self.assertEqual(transducer.edges, [(0, 0), (1, 0), (2, 0)])
-        self.assertEqual(transducer.alignments(), [("abc", "a")])
+        self.assertEqual(transducer.substring_alignments(), [("abc", "a")])
 
     def test_case_eleven(self):
         transducer = self.trans_eleven("a")
         self.assertEqual(transducer.output_string, "aaaa")
         self.assertEqual(transducer.edges, [(0, 0), (0, 1), (0, 2), (0, 3)])
-        self.assertEqual(transducer.alignments(), [("a", "aaaa")])
+        self.assertEqual(transducer.substring_alignments(), [("a", "aaaa")])
 
     def test_case_twelve(self):
         # Empty inputs are not allowed (should it actually throw an exception?)
@@ -519,7 +530,9 @@ class IndicesTest(TestCase):
         tg = transducer("acdc")
         self.assertEqual(tg.output_string, "cacdc")
         self.assertEqual(tg.edges, [(0, 1), (1, 0), (1, 2), (2, 3), (3, 4)])
-        self.assertEqual(tg.alignments(), [("ac", "cac"), ("d", "d"), ("c", "c")])
+        self.assertEqual(
+            tg.substring_alignments(), [("ac", "cac"), ("d", "d"), ("c", "c")]
+        )
 
     def test_case_acac(self):
         transducer = Transducer(Mapping([{"in": "ab{1}c{2}", "out": "ab{2}"}]))
@@ -541,7 +554,7 @@ class IndicesTest(TestCase):
                 (5, 3),
             ],
         )
-        self.assertEqual(tg.alignments(), [("abcab", "ab"), ("c", "ab")])
+        self.assertEqual(tg.substring_alignments(), [("abcab", "ab"), ("c", "ab")])
         tg_default = transducer_default("abcabc")
         self.assertEqual(tg_default.output_string, "abab")
         self.assertEqual(
@@ -557,7 +570,9 @@ class IndicesTest(TestCase):
                 (5, 3),
             ],
         )
-        self.assertEqual(tg_default.alignments(), [("abcab", "ab"), ("c", "ab")])
+        self.assertEqual(
+            tg_default.substring_alignments(), [("abcab", "ab"), ("c", "ab")]
+        )
 
     def test_arpabet(self):
         transducer = Transducer(
@@ -585,7 +600,7 @@ class IndicesTest(TestCase):
                 (1, 9),
             ],
         )
-        self.assertEqual(tg.alignments(), [("ĩ", "IY N "), ("ĩ", "IY N ")])
+        self.assertEqual(tg.substring_alignments(), [("ĩ", "IY N "), ("ĩ", "IY N ")])
         self.assertEqual(
             tg_nfd.edges,
             [
@@ -602,7 +617,8 @@ class IndicesTest(TestCase):
             ],
         )
         self.assertEqual(
-            tg_nfd.alignments(), [("i", "I"), ("̃", "Y N "), ("i", "I"), ("̃", "Y N ")]
+            tg_nfd.substring_alignments(),
+            [("i", "I"), ("̃", "Y N "), ("i", "I"), ("̃", "Y N ")],
         )
 
 

--- a/g2p/tests/test_indices.py
+++ b/g2p/tests/test_indices.py
@@ -165,6 +165,11 @@ class IndicesTest(TestCase):
           ((1, 'b'), (0, '')),
           ((1, 'c'), (0, '')) ]
 
+    Test case # 11
+        # Sort of an insertion test (empty inputs are not allowed)
+
+    Test case # 12
+        # Verify that empty inputs are not allowed
     """
 
     def __init__(self, *args):
@@ -370,9 +375,13 @@ class IndicesTest(TestCase):
         self.assertEqual(
             transducer_lite.edges, [(0, 4), (1, 0), (2, 1), (2, 2), (3, 3)]
         )
+        self.assertEqual(transducer_lite.alignments(), [("abcc", "ccccc")])
         self.assertEqual(
             transducer_lite_extra.edges,
             [(0, 4), (1, 0), (2, 1), (2, 2), (3, 3), (4, 5)],
+        )
+        self.assertEqual(
+            transducer_lite_extra.alignments(), [("abcc", "ccccc"), ("a", "a")]
         )
         transducer_no_i = self.trans_wacky("\U0001f600\U0001f603\U0001f604\U0001f604")
         self.assertEqual(
@@ -385,76 +394,132 @@ class IndicesTest(TestCase):
             "\U0001f604\U0001f604\U0001f604\U0001f604\U0001f604",
         )
         self.assertEqual(transducer.edges, [(0, 4), (1, 0), (2, 1), (2, 2), (3, 3)])
+        self.assertEqual(
+            transducer.alignments(),
+            [
+                (
+                    "\U0001f600\U0001f603\U0001f604\U0001f604",
+                    "\U0001f604\U0001f604\U0001f604\U0001f604\U0001f604",
+                )
+            ],
+        )
 
     def test_circum(self):
         """Test circumfixing"""
         transducer = self.trans_circum("ac")
         self.assertEqual(transducer.output_string, "cac")
         self.assertEqual(transducer.edges, [(0, 1), (1, 0), (1, 2)])
+        self.assertEqual(transducer.alignments(), [("ac", "cac")])
 
     def test_case_one(self):
         """Test case one"""
         transducer = self.trans_one("test")
         self.assertEqual(transducer.output_string, "pest")
         self.assertEqual(transducer.edges, [(0, 0), (1, 1), (2, 2), (3, 3)])
+        self.assertEqual(
+            transducer.alignments(), [("t", "p"), ("e", "e"), ("s", "s"), ("t", "t")]
+        )
 
     def test_case_two(self):
         transducer = self.trans_two("test")
         self.assertEqual(transducer.output_string, "tst")
         self.assertEqual(transducer.edges, [(0, 0), (1, 0), (2, 1), (3, 2)])
+        self.assertEqual(transducer.alignments(), [("te", "t"), ("s", "s"), ("t", "t")])
 
     def test_case_three(self):
         transducer = self.trans_three("test")
         self.assertEqual(transducer.output_string, "chest")
         self.assertEqual(transducer.edges, [(0, 0), (0, 1), (1, 2), (2, 3), (3, 4)])
+        self.assertEqual(
+            transducer.alignments(), [("t", "ch"), ("e", "e"), ("s", "s"), ("t", "t")]
+        )
 
     def test_case_four(self):
         transducer = self.trans_four("test")
         self.assertEqual(transducer.output_string, "pst")
         self.assertEqual(transducer.edges, [(0, 0), (1, 0), (2, 1), (3, 2)])
+        self.assertEqual(transducer.alignments(), [("te", "p"), ("s", "s"), ("t", "t")])
 
     def test_case_six(self):
         transducer = self.trans_six("test")
         self.assertEqual(transducer.output_string, "tset")
         self.assertEqual(transducer.edges, [(0, 0), (1, 2), (2, 1), (3, 3)])
+        self.assertEqual(
+            transducer.alignments(), [("t", "t"), ("es", "se"), ("t", "t")]
+        )
 
     def test_case_long_six(self):
         transducer = self.trans_six("esesse")
         self.assertEqual(transducer.output_string, "sesese")
+        # Ensure that *minimal* monotonic segments are output
+        self.assertEqual(
+            transducer.alignments(),
+            [("es", "se"), ("es", "se"), ("s", "s"), ("e", "e")],
+        )
 
     def test_case_seven(self):
         transducer_as_written = self.test_seven_as_written("test")
         self.assertEqual(transducer_as_written.output_string, "test")
         self.assertEqual(transducer_as_written.edges, [(0, 0), (1, 1), (2, 2), (3, 3)])
+        self.assertEqual(
+            transducer_as_written.alignments(),
+            [("t", "t"), ("e", "e"), ("s", "s"), ("t", "t")],
+        )
         transducer = self.trans_seven("test")
         self.assertEqual(transducer.output_string, "tesht")
         self.assertEqual(transducer.edges, [(0, 0), (1, 1), (2, 2), (2, 3), (3, 4)])
+        self.assertEqual(
+            transducer.alignments(), [("t", "t"), ("e", "e"), ("s", "sh"), ("t", "t")]
+        )
 
     def test_case_eight(self):
         transducer = self.trans_eight("test")
         self.assertEqual(transducer.output_string, "chess")
         self.assertEqual(transducer.edges, [(0, 0), (1, 1), (1, 2), (2, 3), (3, 4)])
+        self.assertEqual(
+            transducer.alignments(), [("t", "c"), ("e", "he"), ("s", "s"), ("t", "s")]
+        )
 
     def test_case_nine(self):
         transducer = self.trans_nine("aa")
         self.assertEqual(transducer.output_string, "")
         self.assertEqual(transducer.edges, [(0, None), (1, None)])
+        # Support deletions in alignments
+        self.assertEqual(transducer.alignments(), [("aa", "")])
 
     def test_case_ten(self):
         transducer = self.trans_ten("abc")
         self.assertEqual(transducer.output_string, "a")
         self.assertEqual(transducer.edges, [(0, 0), (1, 0), (2, 0)])
+        self.assertEqual(transducer.alignments(), [("abc", "a")])
 
     def test_case_eleven(self):
         transducer = self.trans_eleven("a")
         self.assertEqual(transducer.output_string, "aaaa")
         self.assertEqual(transducer.edges, [(0, 0), (0, 1), (0, 2), (0, 3)])
+        self.assertEqual(transducer.alignments(), [("a", "aaaa")])
+
+    def test_case_twelve(self):
+        # Empty inputs are not allowed (should it actually throw an exception?)
+        with self.assertLogs() as cm:
+            self.test_mapping_twelve = Mapping(
+                [{"in": "", "out": "aa", "context_before": "b"}]
+            )
+            self.trans_twelve = Transducer(self.test_mapping_twelve)
+            transducer = self.trans_twelve("b")
+        self.assertIn(
+            "disallowed",
+            cm.output[0],
+            "it should warn that empty inputs are disallowed",
+        )
+        self.assertEqual(transducer.output_string, "b")
 
     def test_case_acdc(self):
         transducer = Transducer(Mapping([{"in": "a{1}c{2}", "out": "c{2}a{1}c{2}"}]))
         tg = transducer("acdc")
         self.assertEqual(tg.output_string, "cacdc")
         self.assertEqual(tg.edges, [(0, 1), (1, 0), (1, 2), (2, 3), (3, 4)])
+        self.assertEqual(tg.alignments(), [("ac", "cac"), ("d", "d"), ("c", "c")])
 
     def test_case_acac(self):
         transducer = Transducer(Mapping([{"in": "ab{1}c{2}", "out": "ab{2}"}]))
@@ -476,6 +541,7 @@ class IndicesTest(TestCase):
                 (5, 3),
             ],
         )
+        self.assertEqual(tg.alignments(), [("abcab", "ab"), ("c", "ab")])
         tg_default = transducer_default("abcabc")
         self.assertEqual(tg_default.output_string, "abab")
         self.assertEqual(
@@ -491,6 +557,7 @@ class IndicesTest(TestCase):
                 (5, 3),
             ],
         )
+        self.assertEqual(tg_default.alignments(), [("abcab", "ab"), ("c", "ab")])
 
     def test_arpabet(self):
         transducer = Transducer(
@@ -518,6 +585,7 @@ class IndicesTest(TestCase):
                 (1, 9),
             ],
         )
+        self.assertEqual(tg.alignments(), [("ĩ", "IY N "), ("ĩ", "IY N ")])
         self.assertEqual(
             tg_nfd.edges,
             [
@@ -532,6 +600,9 @@ class IndicesTest(TestCase):
                 (3, 8),
                 (3, 9),
             ],
+        )
+        self.assertEqual(
+            tg_nfd.alignments(), [("i", "I"), ("̃", "Y N "), ("i", "I"), ("̃", "Y N ")]
         )
 
 

--- a/g2p/tests/test_lexicon_transducer.py
+++ b/g2p/tests/test_lexicon_transducer.py
@@ -106,7 +106,7 @@ class LexiconTransducerTest(TestCase):
         pe = tg.pretty_edges()
         self.assertEqual(
             pe,
-            [["x", "ɛ"], ["x", "k"], ["x", "s"], ["t", "t"], ["r", "ɹ"], ["a", "ʌ"]],
+            [("x", "ɛ"), ("x", "k"), ("x", "s"), ("t", "t"), ("r", "ɹ"), ("a", "ʌ")],
         )
 
     def test_eng_transducer(self):

--- a/g2p/tests/test_tokenize_and_map.py
+++ b/g2p/tests/test_tokenize_and_map.py
@@ -70,7 +70,7 @@ class TokenizeAndMapTest(TestCase):
 
     def test_tokenizing_transducer_edge_chain(self):
         transducer = g2p.make_g2p("fra", "eng-arpabet", tok_lang="fra")
-        edges = transducer("est est").edges
+        edges = [x.edges for x in transducer("est est").tiers]
         ref_edges = [
             # "est est" -> "ɛ ɛ"
             [(0, 0), (1, 0), (2, 0), (3, 1), (4, 2), (5, 2), (6, 2)],
@@ -83,7 +83,7 @@ class TokenizeAndMapTest(TestCase):
 
     def test_tokenizing_transducer_edge_spaces(self):
         transducer = g2p.make_g2p("fra", "eng-arpabet", tok_lang="fra")
-        edges = transducer("  a, ").edges
+        edges = [x.edges for x in transducer("  a, ").tiers]
         ref_edges = [
             # "  a, " -> "  a, "
             [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)],

--- a/g2p/tests/test_tokenize_and_map.py
+++ b/g2p/tests/test_tokenize_and_map.py
@@ -38,6 +38,9 @@ class TokenizeAndMapTest(TestCase):
     def test_tokenizing_transducer(self):
         ref_word_ipa = g2p.make_g2p("mic", "mic-ipa")("sq").output_string
         transducer = g2p.make_g2p("mic", "mic-ipa", tok_lang="mic")
+        self.assertEqual(transducer.transducer.in_lang, transducer.in_lang)
+        self.assertEqual(transducer.transducer.out_lang, transducer.out_lang)
+        self.assertEqual(transducer.transducer, transducer.transducers[0])
         word_ipa = transducer("sq").output_string
         self.assertEqual(word_ipa, ref_word_ipa)
         string_ipa = transducer(self.contextualize("sq")).output_string

--- a/g2p/tests/test_tokenize_and_map.py
+++ b/g2p/tests/test_tokenize_and_map.py
@@ -66,7 +66,7 @@ class TokenizeAndMapTest(TestCase):
         ref_edges = [(0, 0), (1, 0), (2, 0), (3, 1), (4, 2), (5, 2), (6, 2)]
         self.assertEqual(tg.edges, ref_edges)
         ref_alignments = [("est", "ɛ"), (" ", " "), ("est", "ɛ")]
-        self.assertEqual(tg.alignments(), ref_alignments)
+        self.assertEqual(tg.substring_alignments(), ref_alignments)
 
     def test_tokenizing_transducer_edges2(self):
         ref_edges = g2p.make_g2p("fra", "fra-ipa")("ça ça").edges
@@ -104,9 +104,9 @@ class TokenizeAndMapTest(TestCase):
             (6, 6),
         ]
         tg = transducer("est est")
-        self.assertEqual(tg.edges, ref_edges)
+        self.assertEqual(tg.alignments(), ref_edges)
         ref_alignments = [("est", "EH "), (" ", " "), ("est", "EH ")]
-        self.assertEqual(tg.alignments(), ref_alignments)
+        self.assertEqual(tg.substring_alignments(), ref_alignments)
 
         tier_edges = [x.edges for x in tg.tiers]
         ref_tier_edges = [
@@ -118,7 +118,7 @@ class TokenizeAndMapTest(TestCase):
             [(0, 0), (0, 1), (0, 2), (1, 3), (2, 4), (2, 5), (2, 6)],
         ]
         self.assertEqual(tier_edges, ref_tier_edges)
-        tier_alignments = [x.alignments() for x in tg.tiers]
+        tier_alignments = [x.substring_alignments() for x in tg.tiers]
         ref_tier_alignments = [
             [("est", "ɛ"), (" ", " "), ("est", "ɛ")],
             [("ɛ", "ɛ"), (" ", " "), ("ɛ", "ɛ")],
@@ -138,7 +138,7 @@ class TokenizeAndMapTest(TestCase):
             (3, 5),
             (4, 6),
         ]
-        self.assertEqual(transducer("  a, ").edges, ref_edges)
+        self.assertEqual(transducer("  a, ").alignments(), ref_edges)
         tier_edges = [x.edges for x in transducer("  a, ").tiers]
         ref_tier_edges = [
             # "  a, " -> "  a, "

--- a/g2p/tests/test_tokenize_and_map.py
+++ b/g2p/tests/test_tokenize_and_map.py
@@ -70,21 +70,63 @@ class TokenizeAndMapTest(TestCase):
 
     def test_tokenizing_transducer_edge_chain(self):
         transducer = g2p.make_g2p("fra", "eng-arpabet", tok_lang="fra")
-        edges = [x.edges for x in transducer("est est").tiers]
+        # .edges on a transducer is always a single array with the
+        # end-to-end mapping, for a composed transducer we can access
+        # the individual tiers with .tiers
         ref_edges = [
+            # FIXME: space after EH is included in output, which is kind of wrong
+            # "est est" -> "EH  EH "
+            # est -> EH
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (1, 0),
+            (1, 1),
+            (1, 2),
+            (2, 0),
+            (2, 1),
+            (2, 2),
+            # space -> space
+            (3, 3),
+            # est -> EH
+            (4, 4),
+            (4, 5),
+            (4, 6),
+            (5, 4),
+            (5, 5),
+            (5, 6),
+            (6, 4),
+            (6, 5),
+            (6, 6),
+        ]
+        self.assertEqual(transducer("est est").edges, ref_edges)
+        tier_edges = [x.edges for x in transducer("est est").tiers]
+        ref_tier_edges = [
             # "est est" -> "ɛ ɛ"
             [(0, 0), (1, 0), (2, 0), (3, 1), (4, 2), (5, 2), (6, 2)],
             # "ɛ ɛ" -> "ɛ ɛ"
             [(0, 0), (1, 1), (2, 2)],
+            # FIXME: space after EH is included in output, which is kind of wrong
             # "ɛ ɛ" -> "EH  EH "
             [(0, 0), (0, 1), (0, 2), (1, 3), (2, 4), (2, 5), (2, 6)],
         ]
-        self.assertEqual(edges, ref_edges)
+        self.assertEqual(tier_edges, ref_tier_edges)
 
     def test_tokenizing_transducer_edge_spaces(self):
         transducer = g2p.make_g2p("fra", "eng-arpabet", tok_lang="fra")
-        edges = [x.edges for x in transducer("  a, ").tiers]
         ref_edges = [
+            # "  a, " -> "  AA , "
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (2, 3),
+            (2, 4),
+            (3, 5),
+            (4, 6),
+        ]
+        self.assertEqual(transducer("  a, ").edges, ref_edges)
+        tier_edges = [x.edges for x in transducer("  a, ").tiers]
+        ref_tier_edges = [
             # "  a, " -> "  a, "
             [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4)],
             # "  a, " -> "  ɑ, "
@@ -92,7 +134,7 @@ class TokenizeAndMapTest(TestCase):
             # "  ɑ, " -> "  AA , "
             [(0, 0), (1, 1), (2, 2), (2, 3), (2, 4), (3, 5), (4, 6)],
         ]
-        self.assertEqual(edges, ref_edges)
+        self.assertEqual(tier_edges, ref_tier_edges)
 
 
 if __name__ == "__main__":

--- a/g2p/tests/test_transducer.py
+++ b/g2p/tests/test_transducer.py
@@ -95,7 +95,7 @@ class TransducerTest(TestCase):
         self.assertEqual([(0, "b"), (1, "b"), (2, "b"), (3, "b")], tg.output_nodes)
         self.assertEqual([(0, 0), (1, 1), (2, 2), (3, 3)], tg.edges)
         self.assertEqual(
-            [[("a", "b"), ("b", "b"), ("a", "b"), ("b", "b")]], tg.pretty_edges()
+            [("a", "b"), ("b", "b"), ("a", "b"), ("b", "b")], tg.pretty_edges()
         )
         self.assertEqual(1, len(tg.debugger))
         self.assertEqual(2, len(tg.debugger[0]))
@@ -127,7 +127,9 @@ class TransducerTest(TestCase):
         self.assertEqual(2, len(ctg.tiers))
         self.assertEqual([(0, "a"), (1, "b"), (2, "a")], ctg.input_nodes)
         self.assertEqual([(0, "a"), (1, "a"), (2, "a")], ctg.output_nodes)
-        self.assertEqual([(0, 0), (1, 1), (2, 2)], ctg.edges)
+        self.assertEqual(
+            [[(0, 0), (1, 1), (2, 2)], [(0, 0), (1, 1), (2, 2)]], ctg.edges
+        )
         self.assertEqual(
             [
                 [("a", "b"), ("b", "b"), ("a", "b")],
@@ -140,9 +142,8 @@ class TransducerTest(TestCase):
         self.assertEqual([(0, "b"), (1, "b"), (2, "b"), (3, "b")], ctg.input_nodes)
         ctg.output_string = "baba"
         self.assertEqual([(0, "b"), (1, "a"), (2, "b"), (3, "a")], ctg.output_nodes)
-        ctg.debugger = [["spam", "spam", "spam", "spam"]]
-        self.assertEqual(1, len(ctg.debugger))
-        self.assertEqual(4, len(ctg.debugger[0]))
+        with self.assertRaises(ValueError):
+            ctg.debugger = [["spam", "spam", "spam", "spam"]]
         with self.assertRaises(ValueError):
             ctg.edges = [(0, 1), (1, 0), (2, 3), (3, 2)]
         with self.assertRaises(ValueError):
@@ -204,7 +205,7 @@ class TransducerTest(TestCase):
     def test_deletion(self):
         tg = self.test_deletion_transducer("a")
         self.assertEqual(tg.output_string, "")
-        self.assertEqual(tg.pretty_edges(), [[("a", None)]])
+        self.assertEqual(tg.pretty_edges(), [("a", None)])
         self.assertEqual(self.test_deletion_transducer_csv("a").output_string, "")
         self.assertEqual(self.test_deletion_transducer_json("a").output_string, "")
 

--- a/g2p/tests/test_z_local_config.py
+++ b/g2p/tests/test_z_local_config.py
@@ -220,7 +220,7 @@ class LocalConfigTest(TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("[[(0, 0), (1, 0)], [(0, 0), (0, 1)]]", result.output)
         self.assertIn(
-            "[[['e', 'ò'], ['́', 'ò']], [['ò', 'u'], ['ò', '̀']]]", result.output
+            "[[('e', 'ò'), ('́', 'ò')], [('ò', 'u'), ('ò', '̀')]]", result.output
         )
 
         result = self.runner.invoke(
@@ -229,7 +229,7 @@ class LocalConfigTest(TestCase):
         )
         self.assertEqual(result.exit_code, 0)
         self.assertIn("[[(0, 0)], [(0, 0), (0, 1)]]", result.output)
-        self.assertIn("[[['é', 'ò']], [['ò', 'u'], ['ò', '̀']]]", result.output)
+        self.assertIn("[[('é', 'ò')], [('ò', 'u'), ('ò', '̀')]]", result.output)
 
 
 if __name__ == "__main__":

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -7,7 +7,7 @@ which are responsible for performing transductions in the g2p library.
 import copy
 import re
 import unicodedata
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from typing import Dict, List, Optional, Tuple, Union
 
 import text_unidecode
@@ -753,8 +753,7 @@ class Transducer:
                     tg.edges[i] = (edge[0], previous[-1][1])
                 elif following:
                     tg.edges[i] = (edge[0], following[0][1])
-        # FIXME: dict used as an ordered set here
-        tg.edges = list(dict.fromkeys((i, j) for i, j in tg.edges))
+        tg.edges = list(OrderedDict.fromkeys((i, j) for i, j in tg.edges))
         if norm_indices is not None:
             tg.edges = compose_indices(norm_indices, tg.edges)
             tg.input_string = saved_to_convert
@@ -957,7 +956,6 @@ class TokenizingTransducer:
     Attributes:
         transducer (Transducer): A Transducer object for the mapping part
         tokenizer (DefaultTokenizer): A Tokenizer object to split the string before mapping
-
     """
 
     def __init__(

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -265,6 +265,8 @@ class TransductionGraph:
         # print("segments:", segments)
 
         def merge_overlapping_segments(segments):
+            if len(segments) <= 1:
+                return segments
             istart, iend, ostart, oend = segments[0]
             output = []
             for seg in segments[1:]:

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -112,7 +112,7 @@ class TransductionGraph:
 
     @property
     def edges(self) -> List[Tuple[int, int]]:
-        """List[Tuple[int, int]]: A list of edges (input node index, output node index) corresponding to the indices of the transformation"""
+        """A list of edges for the transformation."""
         return self._edges
 
     @edges.setter
@@ -139,7 +139,8 @@ class TransductionGraph:
             f"Sorry, you tried to change the tiers to {value} but they cannot be changed"
         )
 
-    def pretty_edges(self) -> List[Tuple[str, str]]:
+    def pretty_edges(self) -> List[List[Tuple[str, str]]]:
+        """List of edges expressed as strings"""
         edges = self._edges[:]
         edges.sort(key=lambda x: x[0])
         out_edges = []
@@ -153,7 +154,7 @@ class TransductionGraph:
                         self._output_nodes[edge[1]][1],
                     )
                 )
-        return out_edges
+        return [out_edges]
 
     def as_dict(self) -> dict:
         return {
@@ -824,7 +825,7 @@ class CompositeTransductionGraph(TransductionGraph):
 
     @property
     def edges(self) -> List[Tuple[int, int]]:
-        """List[Tuple[int, int]]: A list of edges (input node index, output node index) corresponding to the indices of the transformation"""
+        """Return list of edges (input node index, output node index) corresponding to the indices of the composed transformation"""
         composed = self.tiers[0].edges
         for tier in self.tiers[1:]:
             composed = compose_indices(composed, tier.edges)
@@ -836,20 +837,11 @@ class CompositeTransductionGraph(TransductionGraph):
             f"Sorry, you tried to change the edges to {value} but they cannot be changed"
         )
 
-    def pretty_edges(self):
+    def pretty_edges(self) -> List[List[Tuple[str, str]]]:
+        """List of edges expressed as strings"""
         pretty_edges = []
-        for tier_i, edges in enumerate(self._edges):
-            edges = copy.deepcopy(edges)
-            edges.sort(key=lambda x: x[0])
-            for i, edge in enumerate(edges):
-                if edge[1] is None:
-                    edges[i] = [self.tiers[tier_i].input_nodes[edge[0]][1], None]
-                else:
-                    edges[i] = [
-                        self.tiers[tier_i].input_nodes[edge[0]][1],
-                        self.tiers[tier_i].output_nodes[edge[1]][1],
-                    ]
-            pretty_edges.append(edges)
+        for tier in self._tiers:
+            pretty_edges.extend(tier.pretty_edges())
         return pretty_edges
 
     def as_dict(self):

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -68,7 +68,7 @@ class TransductionGraph:
 
     @property
     def input_string(self) -> str:
-        """str: The input string that initialized the TransductionGraph."""
+        """The input string that initialized the TransductionGraph."""
         return self._input_string
 
     @input_string.setter
@@ -89,7 +89,7 @@ class TransductionGraph:
 
     @property
     def input_nodes(self) -> List[Tuple[int, str]]:
-        """List[Tuple[int, str]]: A list of nodes (index and character string) corresponding to the input"""
+        """List of nodes (index and character string) corresponding to the input"""
         return self._input_nodes
 
     @input_nodes.setter
@@ -100,7 +100,7 @@ class TransductionGraph:
 
     @property
     def output_nodes(self) -> List[Tuple[int, str]]:
-        """List[Tuple[int, str]]: A list of nodes (index and character string) corresponding to the output"""
+        """List of nodes (index and character string) corresponding to the output"""
         return self._output_nodes
 
     @output_nodes.setter
@@ -111,8 +111,11 @@ class TransductionGraph:
 
     @property
     def edges(self) -> List:
-        """A list of edges for the transformation.  This is *not* the same
-        between TransductionGraph and CompositeTransductionGraph."""
+        """List[Tuple[int, int]] of edges for the transformation.
+
+        Note that currently this is *not* the same between
+        TransductionGraph and CompositeTransductionGraph.
+        """
         return self._edges
 
     @edges.setter
@@ -120,10 +123,14 @@ class TransductionGraph:
         self._edges = value
 
     @property
-    def debugger(self):
-        """List[dict]: A list of lists of rules applied during the
-        transformation. Useful for debugging.  Note that this is not the same
-        between TransductionGraph and CompositeTransductionGraph."""
+    def debugger(self) -> List[list]:
+        """List[List[dict]]: A list of lists of rules applied during the
+        transformation. Useful for debugging.
+
+        Note that currently this is *not* the same between TransductionGraph
+        and CompositeTransductionGraph.
+
+        """
         return self._debugger
 
     @debugger.setter
@@ -132,8 +139,8 @@ class TransductionGraph:
 
     @property
     def tiers(self) -> List["TransductionGraph"]:  # noqa: F821
-        """List[TransductionGraph]: A list of TransductionGraph objects for
-        each tier in the graph (there is one tier)."""
+        """A list of TransductionGraph objects for each tier in the graph
+        (there is one tier)."""
         return [self]
 
     @tiers.setter
@@ -143,9 +150,11 @@ class TransductionGraph:
         )
 
     def pretty_edges(self):
-        """List of edges, expressed as strings.  Note that this
-        is unfortunately *not* the same output between TransductionGraph and
-        ComposedTransductionGraph."""
+        """List[Tuple[str, str]] of edges resolved to the string nodes.
+
+        Note that this currently *not* the same output between
+        TransductionGraph and ComposedTransductionGraph.
+        """
         edges = self._edges[:]
         edges.sort(key=lambda x: x[0])
         out_edges = []
@@ -163,9 +172,12 @@ class TransductionGraph:
         return out_edges
 
     def alignments(self) -> List[Tuple[int, int]]:
-        """Return list of alignments (input node index, output node index) for
-        the full transduction.  This *is* the same between TransductionGraph
-        and CompositeTransductionGraph."""
+        """Alignments (input node index, output node index) for the full
+        (possibly composed) transduction.
+
+        Note that this *is* the same between TransductionGraph and
+        CompositeTransductionGraph.
+        """
         return self._edges
 
     def substring_alignments(  # noqa: C901
@@ -957,8 +969,8 @@ class CompositeTransductionGraph(TransductionGraph):
         self._tiers = tg_list
 
     @property
-    def tiers(self):
-        """List[TransductionGraph]: A list of TransductionGraph objects for each tier in the CompositeTransducer"""
+    def tiers(self) -> List[TransductionGraph]:
+        """A list of TransductionGraph objects for each tier in the CompositeTransducer"""
         return self._tiers
 
     @tiers.setter
@@ -968,10 +980,13 @@ class CompositeTransductionGraph(TransductionGraph):
         )
 
     @property
-    def edges(self):
-        """A list of edges for each tier in the transformation. Note that this
-        is unfortunately *not* the same between TransductionGraph and
-        ComposedTransductionGraph."""
+    def edges(self) -> List:
+        """List[List[Tuple[int, int]]] of edges for each tier in the
+        transformation.
+
+        Note that this is unfortunately *not* the same between
+        TransductionGraph and ComposedTransductionGraph.
+        """
         return self._edges
 
     @edges.setter
@@ -981,10 +996,13 @@ class CompositeTransductionGraph(TransductionGraph):
         )
 
     @property
-    def debugger(self):
-        """List[dict]: A list of lists of lists of rules applied during the
-        transformation. Useful for debugging.  Note that this is not the same
-        between TransductionGraph and CompositeTransductionGraph."""
+    def debugger(self) -> List[list]:
+        """List[List[List[dict]]]: A list of lists of lists of rules applied
+        during the transformation. Useful for debugging.  Note that
+        this is not the same between TransductionGraph and
+        CompositeTransductionGraph.
+
+        """
         return self._debugger
 
     @debugger.setter
@@ -994,16 +1012,25 @@ class CompositeTransductionGraph(TransductionGraph):
         )
 
     def pretty_edges(self):
-        """List of edges for each tier, expressed as strings.  Note that this
-        is unfortunately *not* the same output between TransductionGraph and
-        ComposedTransductionGraph."""
+        """List[List[Tuple[str, str]]] of edges for each tier, expressed as
+        strings.
+
+        Note that this is unfortunately *not* the same output between
+        TransductionGraph and ComposedTransductionGraph.
+
+        """
         pretty_edges = []
         for tier in self._tiers:
             pretty_edges.append(tier.pretty_edges())
         return pretty_edges
 
     def alignments(self) -> List[Tuple[int, int]]:
-        """Return list of alignments (input node index, output node index) for the full transduction."""
+        """Return list of alignments (input node index, output node index) for
+        the full transduction.
+
+        Note that this *is* the same between TransductionGraph and
+        CompositeTransductionGraph.
+        """
         composed = self.tiers[0].edges
         for tier in self.tiers[1:]:
             composed = compose_indices(composed, tier.edges)

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -45,6 +45,7 @@ ChangeLog = List[List[int]]
 UNIDECODE_SPECIALS = ["@", "?", "'", ",", ":"]
 
 
+
 class TransductionGraph:
     """This is the object returned after performing a transduction using a Transducer.
 
@@ -240,6 +241,16 @@ class Transducer:
             return intermediate_ord - 983040
         else:
             return -1
+
+    @property
+    def in_lang(self):
+        """Input language node name"""
+        return self.mapping.kwargs.get("in_lang", "und")
+
+    @property
+    def out_lang(self):
+        """Output language node name"""
+        return self.mapping.kwargs.get("out_lang", "und")
 
     def resolve_intermediate_chars(self, output_string):
         """Go through all chars and resolve any intermediate characters from the Private Supplementary Use Area
@@ -865,6 +876,21 @@ class CompositeTransducer:
     def __call__(self, to_convert: str):
         return self.apply_rules(to_convert)
 
+    @property
+    def transducers(self):
+        """Sequence of underlying Transducer objects"""
+        return self._transducers
+
+    @property
+    def in_lang(self):
+        """Input language node name"""
+        return self._transducers[0].in_lang
+
+    @property
+    def out_lang(self):
+        """Output language node name"""
+        return self._transducers[-1].out_lang
+
     def apply_rules(self, to_convert: str):
         tg_list = []
         for transducer in self._transducers:
@@ -937,6 +963,11 @@ class TokenizingTransducer:
                 non_word_tg = TransductionGraph(token["text"])
                 tg += non_word_tg
         return tg
+
+    @property
+    def transducer(self):
+        """Underlying Transducer object"""
+        return self._transducer
 
     def check(self, tg: TransductionGraph, shallow=False, display_warnings=False):
         # The obvious implementation fails, because we need to check only the words, not

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -253,6 +253,11 @@ class Transducer:
         """Output language node name"""
         return self.mapping.kwargs.get("out_lang", "und")
 
+    @property
+    def transducers(self) -> List["Transducer"]:  # noqa: F821
+        """Sequence of underlying Transducer objects"""
+        return [self]
+
     def resolve_intermediate_chars(self, output_string) -> str:
         """Go through all chars and resolve any intermediate characters from the Private Supplementary Use Area
         to their mapped equivalents.
@@ -816,6 +821,20 @@ class CompositeTransductionGraph(TransductionGraph):
     def tiers(self, value):
         raise ValueError(
             f"Sorry, you tried to change the tiers to {value} but they cannot be changed"
+        )
+
+    @property
+    def edges(self) -> List[Tuple[int, int]]:
+        """List[Tuple[int, int]]: A list of edges (input node index, output node index) corresponding to the indices of the transformation"""
+        composed = self.tiers[0].edges
+        for tier in self.tiers[1:]:
+            composed = compose_indices(composed, tier.edges)
+        return composed
+
+    @edges.setter
+    def edges(self, value):
+        raise ValueError(
+            f"Sorry, you tried to change the edges to {value} but they cannot be changed"
         )
 
     def pretty_edges(self):


### PR DESCRIPTION
This PR extracts the parts of #231 not related to the new web API.  Basically, it:

- Documents the fact that `TransductionGraph` and `CompositeTransductionGraph` have incompatible APIs.
- Uses tuples rather than lists for pairs of (input, output), which should obviously be tuples
- Adds an `alignments` method which consistently returns the input to output indices whether they come from a composed or non-composed graph.
- Adds some other properties and methods that try to regularize the interfaces between similar classes.  If we want to really fix them it will be a breaking change, which I have not done here.
- Adds a `substring_alignments` method which returns the minimal monotonic textual alignments for the transduction edges.  More precisely, in the case where there are crossing alignments, it will expand the output segment to include them.  This means that the "alignment" could simply be the entire input mapped to the entire output, but given the nature of actually existing writing systems, this is fairly unlikely :-)
- Adds typechecking all over the place
- Adds tests for alignments and such