### PR TITLE
fix: handle deletions more consistently in lexicon and rules

### DIFF
--- a/g2p/mappings/utils.py
+++ b/g2p/mappings/utils.py
@@ -10,7 +10,7 @@ import unicodedata as ud
 from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, TypeVar, Union
 
 import regex as re
 import yaml
@@ -21,6 +21,7 @@ from g2p.mappings import langs
 
 GEN_DIR = os.path.join(os.path.dirname(langs.__file__), "generated")
 GEN_CONFIG = os.path.join(GEN_DIR, "config.yaml")
+IntOrNone = TypeVar("IntOrNone", bound=Union[int, None])
 
 
 def expand_abbreviations(data: str, abbs: Dict[str, List[str]], recursion_depth=0):
@@ -93,8 +94,8 @@ def normalize(inp: str, norm_form: str):
 
 
 def compose_indices(
-    indices1: List[Tuple[int, int]], indices2: List[Tuple[int, int]]
-) -> List[Tuple[int, int]]:
+    indices1: List[Tuple[int, int]], indices2: List[Tuple[int, IntOrNone]]
+) -> List[Tuple[int, IntOrNone]]:
     """Compose indices1 + indices2 into direct arcs from the inputs of indices1
     to the outputs of indices 2.
 

--- a/g2p/mappings/utils.py
+++ b/g2p/mappings/utils.py
@@ -21,7 +21,6 @@ from g2p.mappings import langs
 
 GEN_DIR = os.path.join(os.path.dirname(langs.__file__), "generated")
 GEN_CONFIG = os.path.join(GEN_DIR, "config.yaml")
-IntOrNone = TypeVar("IntOrNone", bound=Union[int, None])
 
 
 def expand_abbreviations(data: str, abbs: Dict[str, List[str]], recursion_depth=0):
@@ -93,9 +92,15 @@ def normalize(inp: str, norm_form: str):
         return normalized
 
 
+# compose_indices is generic because we would like to propagate the
+# type of its second input, in the case where we *know* there will not
+# be None (NFC and NFD conversions)
+IntOrOptionalInt = TypeVar("IntOrOptionalInt", bound=Union[int, None])
+
+
 def compose_indices(
-    indices1: List[Tuple[int, int]], indices2: List[Tuple[int, IntOrNone]]
-) -> List[Tuple[int, IntOrNone]]:
+    indices1: List[Tuple[int, int]], indices2: List[Tuple[int, IntOrOptionalInt]]
+) -> List[Tuple[int, IntOrOptionalInt]]:
     """Compose indices1 + indices2 into direct arcs from the inputs of indices1
     to the outputs of indices 2.
 

--- a/g2p/tests/public/mappings/hello.aligned.txt
+++ b/g2p/tests/public/mappings/hello.aligned.txt
@@ -1,2 +1,3 @@
 h}HH e}EH l|l}L o}OW
 y}Y o|u}UH '}_ r|e}R
+b}_ o}_ g}_ u}_ s}_

--- a/g2p/tests/test_indices.py
+++ b/g2p/tests/test_indices.py
@@ -501,6 +501,19 @@ class IndicesTest(TestCase):
         self.assertEqual(transducer.edges, [(0, None), (1, None)])
         # Support deletions in substring_alignments
         self.assertEqual(transducer.substring_alignments(), [("aa", "")])
+        transducer = self.trans_nine("aabbaab")
+        self.assertEqual(transducer.output_string, "bbb")
+        self.assertEqual(
+            transducer.edges,
+            [(0, 0), (1, 0), (2, 0), (3, 1), (4, 1), (5, 1), (6, 2)],
+        )
+        # Support deletions in substring_alignments.  NOTE: these
+        # alignments are quite bogus due to the ad-hoc treatment of
+        # deletions by rule-based mappings
+        self.assertEqual(
+            transducer.substring_alignments(),
+            [("aab", "b"), ("baa", "b"), ("b", "b")],
+        )
 
     def test_case_ten(self):
         transducer = self.trans_ten("abc")

--- a/g2p/tests/test_lexicon_transducer.py
+++ b/g2p/tests/test_lexicon_transducer.py
@@ -35,7 +35,7 @@ class LexiconTransducerTest(TestCase):
         self.assertEqual(tg.output_string, "Y UH R ")
         self.assertEqual(
             tg.edges,
-            [(0, 0), (1, 2), (1, 3), (2, 2), (2, 3), (3, None), (4, 5), (5, 5)],
+            [(0, 0), (1, 2), (1, 3), (2, 2), (2, 3), (3, 5), (4, 5), (5, 5)],
         )
 
     def test_load_lexicon_mapping(self):
@@ -74,9 +74,7 @@ class LexiconTransducerTest(TestCase):
         self.assertEqual(tg.edges, [(0, 0), (1, 1), (2, 2), (3, 2), (4, 3), (4, 4)])
         tg = t("you're")
         self.assertEqual(tg.output_string, "jʊɹ")
-        self.assertEqual(
-            tg.edges, [(0, 0), (1, None), (2, 1), (3, None), (4, 2), (5, None)]
-        )
+        self.assertEqual(tg.edges, [(0, 0), (1, 1), (2, 1), (3, 2), (4, 2), (5, 2)])
         tg = t("change")
         self.assertEqual(tg.output_string, "tʃeɪndʒ")
         self.assertEqual(tg.input_string, "change")
@@ -85,20 +83,20 @@ class LexiconTransducerTest(TestCase):
             [
                 (0, 0),
                 (0, 1),
-                (1, None),
+                (1, 2),
                 (2, 2),
                 (2, 3),
                 (3, 4),
                 (4, 5),
                 (4, 6),
-                (5, None),
+                (5, 6),
             ],
         )
         tg = t("chain")
         # These aligments are weird but they are the ones EM gave us
         self.assertEqual(tg.output_string, "tʃeɪn")
         self.assertEqual(tg.input_string, "chain")
-        self.assertEqual(tg.edges, [(0, 0), (0, 1), (1, None), (2, 2), (3, 3), (4, 4)])
+        self.assertEqual(tg.edges, [(0, 0), (0, 1), (1, 2), (2, 2), (3, 3), (4, 4)])
         tg = t("xtra")
         self.assertEqual(tg.output_string, "ɛkstɹʌ")
         self.assertEqual(tg.input_string, "xtra")

--- a/g2p/tests/test_lexicon_transducer.py
+++ b/g2p/tests/test_lexicon_transducer.py
@@ -37,7 +37,9 @@ class LexiconTransducerTest(TestCase):
             tg.edges,
             [(0, 0), (1, 2), (1, 3), (2, 2), (2, 3), (3, 4), (4, 5), (5, 5)],
         )
+        # These alignments are somewhat bogus, hence the name
         tg = t("bogus")
+        self.assertEqual(tg.input_string, "bogus")
         self.assertEqual(tg.output_string, "")
         self.assertEqual(
             tg.edges,
@@ -47,11 +49,37 @@ class LexiconTransducerTest(TestCase):
             tg.substring_alignments(),
             [("bogus", "")],
         )
-        # These alignments are somewhat bogus, hence the name
+        tg = t("bogus")
+        tg += t("hello")
+        self.assertEqual(tg.input_string, "bogushello")
+        self.assertEqual(tg.output_string, "HH EH L OW ")
+        self.assertEqual(
+            tg.edges,
+            [
+                (0, 0),
+                (1, 0),
+                (2, 0),
+                (3, 0),
+                (4, 0),
+                (5, 0),
+                (5, 1),
+                (6, 3),
+                (6, 4),
+                (7, 6),
+                (8, 6),
+                (9, 8),
+                (9, 9),
+            ],
+        )
+        self.assertEqual(
+            tg.substring_alignments(),
+            [("bogush", "HH"), ("e", "EH"), ("ll", "L"), ("o", "OW")],
+        )
         tg = t("hello")
         tg += t("bogus")
         tg += t("you're")
         tg += t("bogus")
+        self.assertEqual(tg.input_string, "hellobogusyou'rebogus")
         self.assertEqual(
             tg.edges,
             [

--- a/g2p/tests/test_lexicon_transducer.py
+++ b/g2p/tests/test_lexicon_transducer.py
@@ -35,7 +35,7 @@ class LexiconTransducerTest(TestCase):
         self.assertEqual(tg.output_string, "Y UH R ")
         self.assertEqual(
             tg.edges,
-            [(0, 0), (1, 2), (1, 3), (2, 2), (2, 3), (3, 5), (4, 5), (5, 5)],
+            [(0, 0), (1, 2), (1, 3), (2, 2), (2, 3), (3, 4), (4, 5), (5, 5)],
         )
         tg = t("bogus")
         self.assertEqual(tg.output_string, "")
@@ -46,6 +46,55 @@ class LexiconTransducerTest(TestCase):
         self.assertEqual(
             tg.substring_alignments(),
             [("bogus", "")],
+        )
+        # These alignments are somewhat bogus, hence the name
+        tg = t("hello")
+        tg += t("bogus")
+        tg += t("you're")
+        tg += t("bogus")
+        self.assertEqual(
+            tg.edges,
+            [
+                (0, 0),
+                (0, 1),
+                (1, 3),
+                (1, 4),
+                (2, 6),
+                (3, 6),
+                (4, 8),
+                (4, 9),
+                (5, 9),
+                (6, 9),
+                (7, 9),
+                (8, 9),
+                (9, 9),
+                (10, 11),
+                (11, 13),
+                (11, 14),
+                (12, 13),
+                (12, 14),
+                (13, 15),
+                (14, 16),
+                (15, 16),
+                (16, 16),
+                (17, 16),
+                (18, 16),
+                (19, 16),
+                (20, 16),
+            ],
+        )
+        self.assertEqual(
+            tg.substring_alignments(),
+            [
+                ("h", "HH"),
+                ("e", "EH"),
+                ("ll", "L"),
+                ("obogus", "OW"),
+                ("y", "Y"),
+                ("ou", "UH"),
+                ("'", " "),
+                ("rebogus", "R"),
+            ],
         )
 
     def test_load_lexicon_mapping(self):
@@ -84,7 +133,7 @@ class LexiconTransducerTest(TestCase):
         self.assertEqual(tg.edges, [(0, 0), (1, 1), (2, 2), (3, 2), (4, 3), (4, 4)])
         tg = t("you're")
         self.assertEqual(tg.output_string, "jʊɹ")
-        self.assertEqual(tg.edges, [(0, 0), (1, 1), (2, 1), (3, 2), (4, 2), (5, 2)])
+        self.assertEqual(tg.edges, [(0, 0), (1, 0), (2, 1), (3, 1), (4, 2), (5, 2)])
         tg = t("change")
         self.assertEqual(tg.output_string, "tʃeɪndʒ")
         self.assertEqual(tg.input_string, "change")
@@ -93,7 +142,7 @@ class LexiconTransducerTest(TestCase):
             [
                 (0, 0),
                 (0, 1),
-                (1, 2),
+                (1, 1),
                 (2, 2),
                 (2, 3),
                 (3, 4),
@@ -104,9 +153,11 @@ class LexiconTransducerTest(TestCase):
         )
         tg = t("chain")
         # These aligments are weird but they are the ones EM gave us
+        # (and the ones that our arbitrary assignment of deletions to
+        # adjacent outputs gives us, too...)
         self.assertEqual(tg.output_string, "tʃeɪn")
         self.assertEqual(tg.input_string, "chain")
-        self.assertEqual(tg.edges, [(0, 0), (0, 1), (1, 2), (2, 2), (3, 3), (4, 4)])
+        self.assertEqual(tg.edges, [(0, 0), (0, 1), (1, 1), (2, 2), (3, 3), (4, 4)])
         tg = t("xtra")
         self.assertEqual(tg.output_string, "ɛkstɹʌ")
         self.assertEqual(tg.input_string, "xtra")

--- a/g2p/tests/test_lexicon_transducer.py
+++ b/g2p/tests/test_lexicon_transducer.py
@@ -37,6 +37,16 @@ class LexiconTransducerTest(TestCase):
             tg.edges,
             [(0, 0), (1, 2), (1, 3), (2, 2), (2, 3), (3, 5), (4, 5), (5, 5)],
         )
+        tg = t("bogus")
+        self.assertEqual(tg.output_string, "")
+        self.assertEqual(
+            tg.edges,
+            [(0, None), (1, None), (2, None), (3, None), (4, None)],
+        )
+        self.assertEqual(
+            tg.substring_alignments(),
+            [("bogus", "")],
+        )
 
     def test_load_lexicon_mapping(self):
         """Test loading a lexicon mapping through a config file."""

--- a/g2p/tests/test_transducer.py
+++ b/g2p/tests/test_transducer.py
@@ -244,6 +244,8 @@ class TransducerTest(TestCase):
         bad_edges = [(0, None), (1, None), (2, 1)]
         self.assertEqual(normalize_edges(bad_edges), [(0, 1), (1, 1), (2, 1)])
         # Otherwise leave it as None
+        bad_edges = []
+        self.assertEqual(normalize_edges(bad_edges), bad_edges)
         bad_edges = [(0, None)]
         self.assertEqual(normalize_edges(bad_edges), bad_edges)
         bad_edges = [(0, None), (1, None)]

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -71,10 +71,8 @@ def normalize_edges(
         if edge[1] is None:
             # if previous exists, use that, otherwise use following, otherwise None
             previous = [x for x in edges[:i] if x[1] is not None]
-            try:
-                following = [x for x in edges[i + 1 :] if x[1] is not None]
-            except IndexError:
-                following = None
+            # Note: if len(edges) == 1, edges[1:] is empty, not an IndexError
+            following = [x for x in edges[i + 1 :] if x[1] is not None]
             if previous:
                 edges[i] = (edge[0], previous[-1][1])
             elif following:


### PR DESCRIPTION
This fixes a couple of things, actually:

- `substring_alignments` wasn't entirely robust in its handling of deletions (i.e. edges with `None` in second position)
- BUT ... these edges actually never occur with rule-based mappings because `None` is systematically (but somewhat arbitrarily) removed in every case unless there is no output to which a deletion could actually be mapped
- BUT ... it wasn't being systematically removed in some cases (dealing with concatenation) so this fixes that
- AND ... there was a bug in the code that did that which could result in an IndexError so this fixes that too
- and now the lexicon-based mappings handle deletions in the same way as the rules
- and the type annotations indicate where `None` can occur (this could still be improved somewhat)