### PR TITLE
refactor(test): when a mapping fails, show test case filename:lineno

### DIFF
--- a/g2p/tests/public/data/__init__.py
+++ b/g2p/tests/public/data/__init__.py
@@ -10,6 +10,7 @@ Each line in the test file consists of SOURCE,TARGET,INPUT,OUTPUT
 import csv
 import os
 from glob import glob
+from typing import List
 
 from g2p.log import LOGGER
 
@@ -20,10 +21,10 @@ DATA_DIR = os.path.dirname(__file__)
 loaded_langs_to_test = None
 
 
-def load_public_test_data():
+def load_public_test_data() -> List[List[str]]:
     """Load public/data/*.?sv for test data in various languages
 
-    Returns: List[List[in_lang, out_lang, in_text, out_text]]
+    Returns: List[List[in_lang, out_lang, in_text, out_text, filename:lineno]]
     """
     global loaded_langs_to_test
     if loaded_langs_to_test is not None:
@@ -57,6 +58,7 @@ def load_public_test_data():
                         f"Please check your data."
                     )
                 else:
+                    row.append(f"{fn}:{i+1}")
                     langs_to_test.append(row)
 
     loaded_langs_to_test = langs_to_test

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -90,7 +90,7 @@ class CliTest(TestCase):
                 ).stdout.strip()
                 if output_string != test[3].strip():
                     LOGGER.warning(
-                        f"test_cli.py: {test[0]}->{test[1]} mapping error: '{test[2]}' "
+                        f"test_cli.py for {test[-1]}: {test[0]}->{test[1]} mapping error: '{test[2]}' "
                         f"should map to '{test[3]}', got '{output_string}' (with {tok_option})."
                     )
                     if error_count == 0:

--- a/g2p/tests/test_langs.py
+++ b/g2p/tests/test_langs.py
@@ -31,8 +31,8 @@ class LangTest(TestCase):
             output_string = transducer(test[2]).output_string.strip()
             if output_string != test[3].strip():
                 LOGGER.warning(
-                    "test_langs.py: mapping error: {} from {} to {} should be {}, got {}".format(
-                        test[2], test[0], test[1], test[3], output_string
+                    "test_langs.py: mapping error for {}: {} from {} to {} should be {}, got {}".format(
+                        test[-1], test[2], test[0], test[1], test[3], output_string
                     )
                 )
                 if error_count == 0:


### PR DESCRIPTION
Bonus: in VSCode, you can click on that in the logs and it takes you to the test case file directly, from within tests/public/data.

I forgot to PR this change earlier.

