### PR TITLE
fix: disable the utf8 fix for windows when running in pytest

### DIFF
--- a/g2p/__init__.py
+++ b/g2p/__init__.py
@@ -29,11 +29,11 @@ from g2p.mappings.langs import LANGS_NETWORK
 from g2p.mappings.tokenizer import make_tokenizer
 from g2p.transducer import CompositeTransducer, TokenizingTransducer, Transducer
 
-if sys.stdout.encoding != "utf8" and hasattr(sys.stdout, "buffer"):
-    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf8")
-
-if sys.stderr.encoding != "utf8" and hasattr(sys.stderr, "buffer"):
-    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf8")
+if "pytest" not in sys.modules:
+    if sys.stdout.encoding != "utf8" and hasattr(sys.stdout, "buffer"):
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf8")
+    if sys.stderr.encoding != "utf8" and hasattr(sys.stderr, "buffer"):
+        sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf8")
 
 if sys.version_info < (3, 6):
     sys.exit(


### PR DESCRIPTION
Minimal fix for #241.

This whole solution for making utf8 the default on Windows is not elegant in the first, and now I realize even in the readalongs CLI, we rely on `import g2p` to fix the stdout and stderr encoding, which is really not elegant!

This patch should make Bronson's project be able to proceed, but we should review how we make g2p and readalongs handle utf-8 on Windows.