### PR TITLE
ci: annotate version tags

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -46,6 +46,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         custom_tag: ${{ steps.determine_tag.outputs.TAG_VERSION }}
+        create_annotated_tag: true
     - name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:


### PR DESCRIPTION
Tags should preferably be annotated, so we know who/what created them, and when.