### PR TITLE
Change make_g2p to have it tokenize by default

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch = True
 source_pkgs = g2p
-omit = *g2p/tests/*
+omit = g2p/tests/*
 
 [report]
 precision = 2

--- a/.github/workflows/studio-release-tests.yml
+++ b/.github/workflows/studio-release-tests.yml
@@ -1,9 +1,7 @@
 name: Run Tests for Studio
 on:
-  pull_request:
-    branches: [release, main]
-  push:
-    branches: [release, main]
+  - push
+  - pull_request
 jobs:
   test-studio:
     runs-on: ubuntu-latest

--- a/.github/workflows/studio-release-tests.yml
+++ b/.github/workflows/studio-release-tests.yml
@@ -17,7 +17,7 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements/requirements.test.txt
           pip install -e .
-          pip install coverage coveralls
+          pip install coverage
       - name: Ensure browser is installed
         run: python -m playwright install --with-deps chromium
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           pip install -e .
           pip install pip-licenses
           if pip-licenses | grep -v 'Artistic License' | grep -v LGPL | grep GNU; then echo 'Please avoid introducing *GPL dependencies'; false; fi
-          pip install coverage coveralls
+          pip install coverage
       - name: Run tests
         run: |
           coverage run --omit g2p/app.py --omit 'g2p/tests/*' --parallel-mode \

--- a/g2p/__init__.py
+++ b/g2p/__init__.py
@@ -33,7 +33,7 @@ from g2p.mappings.langs import LANGS, LANGS_NETWORK
 from g2p.mappings.tokenizer import make_tokenizer
 from g2p.transducer import CompositeTransducer, TokenizingTransducer, Transducer
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 6):  # pragma: no cover
     sys.exit(
         f"Python 3.6 or more recent is required. You are using {sys.version}.\n"
         "Please use a newer version of Python."

--- a/g2p/__init__.py
+++ b/g2p/__init__.py
@@ -4,12 +4,12 @@ Basic init file for g2p module
 
 The main entry points for the g2p module are:
  - make_g2p() to create a mapper from and lang to another
- - make_tokenizer() to create a tokenizeer for a given language
+ - make_tokenizer() to create a tokenizer for a given language
  - get_arpabet_langs() to get the list of languages with a path to eng-arpabet
 
 Basic Usage:
     from g2p import make_g2p
-    converter = make_g2p(in_lang, out_lang, tok_lang)
+    converter = make_g2p(in_lang, out_lang)
     transduction_graph = converter(input_text_in_in_alang)
     converted_text_in_out_lang = transduction_graph.output_string
 
@@ -51,17 +51,17 @@ def make_g2p(  # noqa: C901
     """Make a g2p Transducer for mapping text from in_lang to out_lang via the
     shortest path between them.
 
-    In general you should also add `tok_lang` to specify the language
-    for tokenization (probably the same as `in_lang`), because
-    transducers are not guaranteed to deal with whitespace,
+    By default, the input is tokenized using the path of mappings from in_lang
+    to out_lang, because transducers are not guaranteed to deal with whitespace,
     punctuation, etc, properly.
 
     Args:
         in_lang (str): input language code
         out_lang (str): output language code
         tok_lang (Optional[str]): DEPRECATED language for tokenization
-        tokenize (bool): whether tokenization should happen (default: yes)
-        custom_tokenizer (Tokenizer): the tokenizer to use (default: a tokenizer built on the)
+        tokenize (bool): whether tokenization should happen (default: True)
+        custom_tokenizer (Tokenizer): the tokenizer to use (default: a tokenizer
+                                      built on the path from in_lang and out_lang)
 
     Returns:
         Transducer from in_lang to out_lang, optionally with a tokenizer.
@@ -69,8 +69,8 @@ def make_g2p(  # noqa: C901
     Raises:
         InvalidLanguageCode: if in_lang or out_lang don't exist
         NoPath: if there is path between in_lang and out_lang
-
     """
+
     if (in_lang, out_lang, tok_lang, tokenize, id(custom_tokenizer)) in _g2p_cache:
         return _g2p_cache[(in_lang, out_lang, tok_lang, tokenize, id(custom_tokenizer))]
 

--- a/g2p/__init__.py
+++ b/g2p/__init__.py
@@ -20,41 +20,18 @@ Basic Usage:
     from g2p import get_arpabet_langs
     LANGS, LANG_NAMES = get_arpabet_langs()
 """
-import sys
 from typing import Dict, Optional, Tuple, Union
 
 from networkx import has_path, shortest_path
 from networkx.exception import NetworkXNoPath
 
+import g2p.deprecation
 from g2p.exceptions import InvalidLanguageCode, NoPath
 from g2p.log import LOGGER
 from g2p.mappings import Mapping
 from g2p.mappings.langs import LANGS, LANGS_NETWORK
 from g2p.mappings.tokenizer import Tokenizer, make_tokenizer
 from g2p.transducer import CompositeTransducer, TokenizingTransducer, Transducer
-from g2p._version import VERSION
-
-if sys.version_info < (3, 6):  # pragma: no cover
-    sys.exit(
-        f"Python 3.6 or more recent is required. You are using {sys.version}.\n"
-        "Please use a newer version of Python."
-    )
-
-
-def _handle_tok_lang_deprecation(tok_lang):
-    """Warn or raise about using the deprecated tok_lang arg to make_g2p"""
-    if tok_lang:
-        if VERSION < "2.0":
-            LOGGER.warning(
-                "Deprecation warning: the tok_lang argument to make_g2p is deprecated, "
-                "and will be removed in g2p version 2.0 "
-                "Use tokenize=True or create a custom_tokenizer using make_tokenizer() instead."
-            )
-        else:
-            raise TypeError(
-                "Deprecation error: the tok_lang argument to make_g2p has been removed. "
-                "Use tokenize=True or create a custom_tokenizer using make_tokenizer() instead."
-            )
 
 
 _g2p_cache: Dict[
@@ -97,7 +74,7 @@ def make_g2p(  # noqa: C901
     if (in_lang, out_lang, tok_lang, tokenize, id(custom_tokenizer)) in _g2p_cache:
         return _g2p_cache[(in_lang, out_lang, tok_lang, tokenize, id(custom_tokenizer))]
 
-    _handle_tok_lang_deprecation(tok_lang)
+    g2p.deprecation.handle_tok_lang_deprecation(tok_lang)
 
     # Check in_lang is a node in network
     if in_lang not in LANGS_NETWORK.nodes:

--- a/g2p/_version.py
+++ b/g2p/_version.py
@@ -1,3 +1,3 @@
 # -*- coding: UTF-8 -*-o
 
-VERSION = "1.0"
+VERSION = "1.1"

--- a/g2p/api.py
+++ b/g2p/api.py
@@ -119,7 +119,7 @@ class Text(Resource):
         index = args["index"]
         debugger = args["debugger"]
         try:
-            transducer = make_g2p(in_lang, out_lang)
+            transducer = make_g2p(in_lang, out_lang, tokenize=False)
             tg = transducer(text)
             text = tg.output_string
             input_text = tg.input_string

--- a/g2p/app.py
+++ b/g2p/app.py
@@ -202,12 +202,14 @@ def change_table(message):
         # because it is the individual ones which are cached by g2p
         path = shortest_path(LANGS_NETWORK, message["in_lang"], message["out_lang"])
         if len(path) == 1:
-            transducer = make_g2p(message["in_lang"], message["out_lang"])
+            transducer = make_g2p(
+                message["in_lang"], message["out_lang"], tokenize=False
+            )
             mappings = [transducer.mapping]
         else:
             mappings = []
             for lang1, lang2 in zip(path[:-1], path[1:]):
-                transducer = make_g2p(lang1, lang2)
+                transducer = make_g2p(lang1, lang2, tokenize=False)
                 mappings.append(transducer.mapping)
         emit(
             "table response",

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -477,11 +477,6 @@ def generate_mapping(  # noqa: C901
     help="Tokenize INPUT_TEXT before converting.",
 )
 @click.option(
-    "--path",
-    type=click.Path(exists=True, file_okay=True, dir_okay=False),
-    help="Read text to convert from FILE.",
-)
-@click.option(
     "--config",
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
     help="A path to a mapping configuration file to use",
@@ -564,10 +559,8 @@ def convert(  # noqa: C901
     if tok and tok_lang is None:
         tok_lang = "path"
     # Transduce!!!
-    if in_lang and out_lang:
-        transducer = make_g2p(in_lang, out_lang, tok_lang=tok_lang)
-    elif path:
-        transducer = Transducer(Mapping(path))
+    assert in_lang and out_lang
+    transducer = make_g2p(in_lang, out_lang, tok_lang=tok_lang)
     tg = transducer(input_text)
     if check:
         transducer.check(tg, display_warnings=True)

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -474,7 +474,7 @@ def generate_mapping(  # noqa: C901
     "-t",
     default=None,  # three-way var: None=not set, True/False=set to True/False
     is_flag=True,
-    help="Tokenize INPUT_TEXT before converting.",
+    help="Tokenize INPUT_TEXT before converting. Default is --tok, specify --no-tok to turn off.",
 )
 @click.option(
     "--config",
@@ -555,6 +555,8 @@ def convert(  # noqa: C901
     # Determine which tokenizer to use, if any
     if tok is not None and not tok and tok_lang is not None:
         raise click.UsageError("Specified conflicting --no-tok and --tok-lang options.")
+    if tok is None:
+        tok = True  # Tokenize by default
     custom_tokenizer = make_tokenizer(tok_lang) if tok_lang else None
     # Transduce!!!
     assert in_lang and out_lang

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -13,7 +13,7 @@ import yaml
 from flask.cli import FlaskGroup
 from networkx import has_path
 
-from g2p import make_g2p
+from g2p import make_g2p, make_tokenizer
 from g2p._version import VERSION
 from g2p.api import update_docs
 from g2p.app import APP
@@ -492,7 +492,6 @@ def convert(  # noqa: C901
     in_lang,
     out_lang,
     input_text,
-    path,
     tok,
     check,
     debugger,
@@ -556,11 +555,12 @@ def convert(  # noqa: C901
     # Determine which tokenizer to use, if any
     if tok is not None and not tok and tok_lang is not None:
         raise click.UsageError("Specified conflicting --no-tok and --tok-lang options.")
-    if tok and tok_lang is None:
-        tok_lang = "path"
+    custom_tokenizer = make_tokenizer(tok_lang) if tok_lang else None
     # Transduce!!!
     assert in_lang and out_lang
-    transducer = make_g2p(in_lang, out_lang, tok_lang=tok_lang)
+    transducer = make_g2p(
+        in_lang, out_lang, tokenize=tok, custom_tokenizer=custom_tokenizer
+    )
     tg = transducer(input_text)
     if check:
         transducer.check(tg, display_warnings=True)
@@ -740,7 +740,7 @@ def show_mappings(lang1, lang2, verbose, csv):
 
     if lang1 is not None and lang2 is not None:
         try:
-            transducer = make_g2p(lang1, lang2)
+            transducer = make_g2p(lang1, lang2, tokenize=False)
         except (NoPath, InvalidLanguageCode) as e:
             raise click.UsageError(
                 f'Cannot find mapping from "{lang1}" to "{lang2}": {e}'

--- a/g2p/deprecation.py
+++ b/g2p/deprecation.py
@@ -5,8 +5,8 @@ version validated. Other functions can be added and invoked as needed.
 """
 
 import sys
+import warnings
 
-from g2p.log import LOGGER
 import g2p._version
 
 if sys.version_info < (3, 6):  # pragma: no cover
@@ -20,10 +20,15 @@ def handle_tok_lang_deprecation(tok_lang):
     """Warn or raise about using the deprecated tok_lang arg to make_g2p"""
     if tok_lang:
         if g2p._version.VERSION < "2.0":
-            LOGGER.warning(
+            warnings.filterwarnings(
+                "default", category=DeprecationWarning, message=".*make_g2p.*"
+            )
+            warnings.warn(
                 "Deprecation warning: the tok_lang argument to make_g2p is deprecated, "
                 "and will be removed in g2p version 2.0 "
-                "Use tokenize=True or create a custom_tokenizer using make_tokenizer() instead."
+                "Use tokenize=True or create a custom_tokenizer using make_tokenizer() instead.",
+                DeprecationWarning,
+                stacklevel=3,
             )
         else:
             raise TypeError(

--- a/g2p/deprecation.py
+++ b/g2p/deprecation.py
@@ -1,0 +1,32 @@
+"""Hide deprecation and version checking code here so it's not in the way.
+
+Usage: g2p.__init__ should simply do "import g2p.deprecation" in order to get the Python
+version validated. Other functions can be added and invoked as needed.
+"""
+
+import sys
+
+from g2p.log import LOGGER
+import g2p._version
+
+if sys.version_info < (3, 6):  # pragma: no cover
+    sys.exit(
+        f"Python 3.6 or more recent is required by g2p. You are using {sys.version}.\n"
+        "Please use a newer version of Python."
+    )
+
+
+def handle_tok_lang_deprecation(tok_lang):
+    """Warn or raise about using the deprecated tok_lang arg to make_g2p"""
+    if tok_lang:
+        if g2p._version.VERSION < "2.0":
+            LOGGER.warning(
+                "Deprecation warning: the tok_lang argument to make_g2p is deprecated, "
+                "and will be removed in g2p version 2.0 "
+                "Use tokenize=True or create a custom_tokenizer using make_tokenizer() instead."
+            )
+        else:
+            raise TypeError(
+                "Deprecation error: the tok_lang argument to make_g2p has been removed. "
+                "Use tokenize=True or create a custom_tokenizer using make_tokenizer() instead."
+            )

--- a/g2p/mappings/create_fallback_mapping.py
+++ b/g2p/mappings/create_fallback_mapping.py
@@ -23,7 +23,7 @@ def align_to_dummy_fallback(
             mapping.inventory(io), DUMMY_INVENTORY, distance=distance, quiet=quiet
         )
     else:
-        und_g2p = make_g2p("und", "und-ipa")
+        und_g2p = make_g2p("und", "und-ipa", tokenize=False)
         mapping = [
             {
                 "in": unicode_escape(x),

--- a/g2p/tests/test_check_ipa_arpabet.py
+++ b/g2p/tests/test_check_ipa_arpabet.py
@@ -33,7 +33,7 @@ class CheckIpaArpabetTest(TestCase):
         self.assertFalse(transducer.check(transducer("ñ")))
 
     def test_check_ipa(self):
-        transducer = make_g2p("fra", "fra-ipa")
+        transducer = make_g2p("fra", "fra-ipa", tokenize=False)
         self.assertTrue(transducer.check(transducer("ceci")))
         self.assertFalse(transducer.check(transducer("ñ")))
         with self.assertLogs(LOGGER, level="WARNING"):
@@ -49,12 +49,12 @@ class CheckIpaArpabetTest(TestCase):
         self.assertTrue(utils.is_panphon("ɻ̊j̊ oⁿk oᵐp"))
 
     def test_check_composite_transducer(self):
-        transducer = make_g2p("fra", "eng-arpabet")
+        transducer = make_g2p("fra", "eng-arpabet", tokenize=False)
         self.assertTrue(transducer.check(transducer("ceci est un test été à")))
         self.assertFalse(transducer.check(transducer("ñ")))
 
     def test_check_tokenizing_transducer(self):
-        transducer = make_g2p("fra", "fra-ipa", tok_lang="fra")
+        transducer = make_g2p("fra", "fra-ipa")
         self.assertTrue(transducer.check(transducer("ceci est un test été à")))
         self.assertFalse(transducer.check(transducer("ñ oǹ")))
         self.assertTrue(
@@ -65,7 +65,7 @@ class CheckIpaArpabetTest(TestCase):
         )
 
     def test_check_tokenizing_composite_transducer(self):
-        transducer = make_g2p("fra", "eng-arpabet", tok_lang="fra")
+        transducer = make_g2p("fra", "eng-arpabet")
         self.assertTrue(transducer.check(transducer("ceci est un test été à")))
         self.assertFalse(transducer.check(transducer("ñ oǹ")))
         self.assertTrue(
@@ -83,7 +83,7 @@ class CheckIpaArpabetTest(TestCase):
             )
 
     def test_shallow_check(self):
-        transducer = make_g2p("win", "eng-arpabet", tok_lang="win")
+        transducer = make_g2p("win", "eng-arpabet")
         # This is False, but should be True! It's False because the mapping outputs :
         # instead of ː
         # EJJ 2022-06-16 With #100 fixed, this check is no longer failing.
@@ -92,16 +92,16 @@ class CheckIpaArpabetTest(TestCase):
         self.assertTrue(transducer.check(transducer("uu"), shallow=True))
 
     def test_check_with_equiv(self):
-        transducer = make_g2p("tau", "eng-arpabet", tok_lang="tau")
-        tau_ipa = make_g2p("tau", "tau-ipa", tok_lang="tau")(
+        transducer = make_g2p("tau", "eng-arpabet")
+        tau_ipa = make_g2p("tau", "tau-ipa")(
             "sh'oo Jign maasee' do'eent'aa shyyyh"
         ).output_string
         self.assertTrue(utils.is_panphon(tau_ipa))
-        eng_ipa = make_g2p("tau", "eng-ipa", tok_lang="tau")(
+        eng_ipa = make_g2p("tau", "eng-ipa")(
             "sh'oo Jign maasee' do'eent'aa shyyyh"
         ).output_string
         self.assertTrue(utils.is_panphon(eng_ipa))
-        eng_arpabet = make_g2p("tau", "eng-arpabet", tok_lang="tau")(
+        eng_arpabet = make_g2p("tau", "eng-arpabet")(
             "sh'oo Jign maasee' do'eent'aa shyyyh"
         ).output_string
         self.assertTrue(utils.is_arpabet(eng_arpabet))

--- a/g2p/tests/test_lexicon_transducer.py
+++ b/g2p/tests/test_lexicon_transducer.py
@@ -203,6 +203,11 @@ class LexiconTransducerTest(TestCase):
         tg = transducer("hello")
         self.assertEqual(tg.output_string, "HH AH L OW ")
 
+        # since we tokenize by default now, this works:
+        self.assertEqual(
+            transducer("hello my friend").output_string, "HH AH L OW  M AY  F R EH N D "
+        )
+
 
 if __name__ == "__main__":
     main()

--- a/g2p/tests/test_network.py
+++ b/g2p/tests/test_network.py
@@ -27,12 +27,12 @@ class NetworkTest(TestCase):
             make_g2p("hei", "git")
 
     def test_valid_composite(self):
-        transducer = make_g2p("atj", "eng-ipa")
+        transducer = make_g2p("atj", "eng-ipa", tokenize=False)
         self.assertTrue(isinstance(transducer, CompositeTransducer))
         self.assertEqual("niɡiɡw", transducer("nikikw").output_string)
 
     def test_valid_transducer(self):
-        transducer = make_g2p("atj", "atj-ipa")
+        transducer = make_g2p("atj", "atj-ipa", tokenize=False)
         self.assertTrue(isinstance(transducer, Transducer))
         self.assertEqual("niɡiɡw", transducer("nikikw").output_string)
 

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -13,6 +13,7 @@ or robust server mode (*nix only, gunicorn does not work on Windows):
 """
 
 from datetime import datetime
+from random import sample
 
 # flake8: noqa: C901
 from unittest import IsolatedAsyncioTestCase, main
@@ -85,6 +86,16 @@ class StudioTest(IsolatedAsyncioTestCase):
     async def test_langs(self):
 
         langs_to_test = load_public_test_data()
+        # Doing the whole test set takes a long time, so let's use a 10% random sample,
+        # knowing that all cases always get exercised in test_cli.py and test_langs.py.
+        # 10% is enough to catch a sudden drift where the studio might stop being campatible.
+        langs_to_test = [
+            langs_to_test[i]
+            for i in sorted(
+                sample(range(len(langs_to_test)), k=len(langs_to_test) // 10)
+            )
+        ]
+
         error_count = 0
 
         # The current g2p-studio app leaks memory, so that if we try to run all the test

--- a/g2p/tests/test_tokenize_and_map.py
+++ b/g2p/tests/test_tokenize_and_map.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
+import warnings
 from unittest import TestCase, main
 
 import g2p
-from g2p.log import LOGGER
 
 
 class TokenizeAndMapTest(TestCase):
@@ -155,8 +155,10 @@ class TokenizeAndMapTest(TestCase):
 
     def test_deprecated_tok_langs(self):
         if g2p._version.VERSION < "2.0":
-            with self.assertLogs(LOGGER, "WARNING"):
+            with warnings.catch_warnings(record=True) as w:
                 _ = g2p.make_g2p("fin", "eng-arpabet", "path")
+                self.assertEqual(len(w), 1)
+                self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
         else:
             with self.assertRaises(TypeError):
                 _ = g2p.make_g2p("fin", "eng-arpabet", "path")
@@ -166,7 +168,7 @@ class TokenizeAndMapTest(TestCase):
         saved_version = g2p._version.VERSION
         g2p._version.VERSION = "2.0"
         with self.assertRaises(TypeError):
-            _ = g2p.make_g2p("ikt-sro", "eng-ipa", "path")
+            _ = g2p.make_g2p("iku-sro", "eng-ipa", "path")
         g2p._version.VERSION = saved_version
 
     def test_make_g2p_cache(self):

--- a/g2p/tests/test_tokenize_and_map.py
+++ b/g2p/tests/test_tokenize_and_map.py
@@ -17,7 +17,7 @@ class TokenizeAndMapTest(TestCase):
 
     def test_tok_and_map_fra(self):
         """Chaining tests: tokenize and map a string"""
-        transducer = g2p.make_g2p("fra", "fra-ipa")
+        transducer = g2p.make_g2p("fra", "fra-ipa", tokenize=False)
         tokenizer = g2p.make_tokenizer("fra")
         # "teste" in isolation is at string and word end and beginning
         word_ipa = transducer("teste").output_string
@@ -28,7 +28,7 @@ class TokenizeAndMapTest(TestCase):
         self.assertEqual(string_ipa, self.contextualize(word_ipa))
 
     def test_tok_and_map_mic(self):
-        transducer = g2p.make_g2p("mic", "mic-ipa")
+        transducer = g2p.make_g2p("mic", "mic-ipa", tokenize=False)
         tokenizer = g2p.make_tokenizer("mic")
         word_ipa = transducer("sq").output_string
         string_ipa = g2p.tokenize_and_map(
@@ -37,8 +37,10 @@ class TokenizeAndMapTest(TestCase):
         self.assertEqual(string_ipa, self.contextualize(word_ipa))
 
     def test_tokenizing_transducer(self):
-        ref_word_ipa = g2p.make_g2p("mic", "mic-ipa")("sq").output_string
-        transducer = g2p.make_g2p("mic", "mic-ipa", tok_lang="mic")
+        ref_word_ipa = g2p.make_g2p("mic", "mic-ipa", tokenize=False)(
+            "sq"
+        ).output_string
+        transducer = g2p.make_g2p("mic", "mic-ipa")  # tokenizes on "mic" via "path"
         self.assertEqual(transducer.transducer.in_lang, transducer.in_lang)
         self.assertEqual(transducer.transducer.out_lang, transducer.out_lang)
         self.assertEqual(transducer.transducer, transducer.transducers[0])
@@ -48,19 +50,19 @@ class TokenizeAndMapTest(TestCase):
         self.assertEqual(string_ipa, self.contextualize(ref_word_ipa))
 
     def test_tokenizing_transducer_chain(self):
-        transducer = g2p.make_g2p("fra", "eng-arpabet", tok_lang="fra")
+        transducer = g2p.make_g2p("fra", "eng-arpabet")
         self.assertEqual(
             self.contextualize(transducer("teste").output_string),
             transducer(self.contextualize("teste")).output_string,
         )
 
     def test_tokenizing_transducer_debugger(self):
-        transducer = g2p.make_g2p("fra", "fra-ipa", tok_lang="fra")
+        transducer = g2p.make_g2p("fra", "fra-ipa")
         debugger = transducer("ceci est un test.").debugger
         self.assertEqual(len(debugger), 4)
 
     def test_tokenizing_transducer_edges(self):
-        transducer = g2p.make_g2p("fra", "fra-ipa", tok_lang="fra")
+        transducer = g2p.make_g2p("fra", "fra-ipa")
         tg = transducer("est est")
         # est -> ɛ, so edges are (0, 0), (1, 0), (2, 0) for each "est", plus the
         # space to the space, and the second set of edges being offset
@@ -70,12 +72,12 @@ class TokenizeAndMapTest(TestCase):
         self.assertEqual(tg.substring_alignments(), ref_alignments)
 
     def test_tokenizing_transducer_edges2(self):
-        ref_edges = g2p.make_g2p("fra", "fra-ipa")("ça ça").edges
-        edges = g2p.make_g2p("fra", "fra-ipa", tok_lang="fra")("ça ça").edges
+        ref_edges = g2p.make_g2p("fra", "fra-ipa", tokenize=False)("ça ça").edges
+        edges = g2p.make_g2p("fra", "fra-ipa")("ça ça").edges
         self.assertEqual(edges, ref_edges)
 
     def test_tokenizing_transducer_edge_chain(self):
-        transducer = g2p.make_g2p("fra", "eng-arpabet", tok_lang="fra")
+        transducer = g2p.make_g2p("fra", "eng-arpabet")
         # .edges on a transducer is always a single array with the
         # end-to-end mapping, for a composed transducer we can access
         # the individual tiers with .tiers
@@ -128,7 +130,7 @@ class TokenizeAndMapTest(TestCase):
         self.assertEqual(tier_alignments, ref_tier_alignments)
 
     def test_tokenizing_transducer_edge_spaces(self):
-        transducer = g2p.make_g2p("fra", "eng-arpabet", tok_lang="fra")
+        transducer = g2p.make_g2p("fra", "eng-arpabet")
         ref_edges = [
             # "  a, " -> "  AA , "
             (0, 0),

--- a/g2p/tests/test_tokenize_and_map.py
+++ b/g2p/tests/test_tokenize_and_map.py
@@ -152,7 +152,7 @@ class TokenizeAndMapTest(TestCase):
         self.assertEqual(tier_edges, ref_tier_edges)
 
     def test_deprecated_tok_langs(self):
-        if g2p.VERSION < "2.0":
+        if g2p._version.VERSION < "2.0":
             with self.assertLogs(LOGGER, "WARNING"):
                 _ = g2p.make_g2p("fin", "eng-arpabet", "path")
         else:
@@ -162,10 +162,10 @@ class TokenizeAndMapTest(TestCase):
     def test_removed_tok_langs_in_v2(self):
         # monkey patch to make sure we always exercise the TypeError pathway
         saved_version = g2p._version.VERSION
-        g2p.VERSION = "2.0"
+        g2p._version.VERSION = "2.0"
         with self.assertRaises(TypeError):
             _ = g2p.make_g2p("ikt-sro", "eng-ipa", "path")
-        g2p.VERSION = saved_version
+        g2p._version.VERSION = saved_version
 
     def test_make_g2p_cache(self):
         self.assertIs(

--- a/g2p/tests/test_unidecode_transducer.py
+++ b/g2p/tests/test_unidecode_transducer.py
@@ -18,7 +18,7 @@ class UnidecodeTransducerTest(TestCase):
         self.assertEqual(tg.output_string, "ete Nunavut nonafot")
 
     def test_unidecode_g2p(self):
-        transducer = make_g2p("und", "und-ascii")
+        transducer = make_g2p("und", "und-ascii", tokenize=False)
         tg = transducer(normalize("éçà", "NFD"))
         self.assertEqual(tg.output_string, "eca")
         self.assertEqual(tg.edges, [(0, 0), (1, 0), (2, 1), (3, 1), (4, 2), (5, 2)])
@@ -28,14 +28,14 @@ class UnidecodeTransducerTest(TestCase):
         self.assertEqual(tg.edges, [(0, 0), (1, 1), (2, 2)])
 
     def test_unidecode_empty_output(self):
-        transducer = make_g2p("und", "und-ascii")
+        transducer = make_g2p("und", "und-ascii", tokenize=False)
         # \u0361 on its own gets deleted completely by unidecode
         tg = transducer("\u0361")
         self.assertEqual(tg.output_string, "")
         self.assertEqual(tg.edges, [])
 
     def test_unidecode_to_arpabet(self):
-        transducer = make_g2p("und", "eng-arpabet")
+        transducer = make_g2p("und", "eng-arpabet", tokenize=False)
         tg = transducer("été Nunavut ᓄᓇᕗᑦ")
         self.assertEqual(
             tg.output_string, "EY T EY  N UW N AA V UW T  N OW N AA F OW T "
@@ -57,7 +57,7 @@ class UnidecodeTransducerTest(TestCase):
         self.assertEqual(tg.output_string, "D IY B EY N Y UW ")
 
     def test_unidecode_hanzi_to_arpabet(self):
-        transducer = make_g2p("und", "eng-arpabet")
+        transducer = make_g2p("und", "eng-arpabet", tokenize=False)
         tg = transducer("你们好!你们说汉语马?")
         self.assertEqual(
             tg.output_string,

--- a/g2p/tests/test_z_local_config.py
+++ b/g2p/tests/test_z_local_config.py
@@ -215,7 +215,16 @@ class LocalConfigTest(TestCase):
         config_path = self.mappings_dir / "compose.yaml"
         result = self.runner.invoke(
             convert,
-            [normalize("é", "NFD"), "c1", "c3", "--config", config_path, "-d", "-e"],
+            [
+                normalize("é", "NFD"),
+                "c1",
+                "c3",
+                "--no-tok",
+                "--config",
+                config_path,
+                "-d",
+                "-e",
+            ],
         )
         self.assertEqual(result.exit_code, 0)
         self.assertIn("[[(0, 0), (1, 0)], [(0, 0), (0, 1)]]", result.output)
@@ -225,7 +234,16 @@ class LocalConfigTest(TestCase):
 
         result = self.runner.invoke(
             convert,
-            [normalize("é", "NFC"), "c1", "c3", "--config", config_path, "-d", "-e"],
+            [
+                normalize("é", "NFC"),
+                "c1",
+                "c3",
+                "--no-tok",
+                "--config",
+                config_path,
+                "-d",
+                "-e",
+            ],
         )
         self.assertEqual(result.exit_code, 0)
         self.assertIn("[[(0, 0)], [(0, 0), (0, 1)]]", result.output)

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -15,7 +15,7 @@ import text_unidecode
 from g2p.log import LOGGER
 from g2p.mappings import Mapping
 from g2p.mappings.langs.utils import is_arpabet, is_panphon
-from g2p.mappings.tokenizer import DefaultTokenizer
+from g2p.mappings.tokenizer import Tokenizer
 from g2p.mappings.utils import (
     compose_indices,
     is_ipa,
@@ -1180,13 +1180,13 @@ class TokenizingTransducer:
 
     Attributes:
         transducer (Transducer): A Transducer object for the mapping part
-        tokenizer (DefaultTokenizer): A Tokenizer object to split the string before mapping
+        tokenizer (Tokenizer): A Tokenizer object to split the string before mapping
     """
 
     def __init__(
         self,
         transducer: Union[Transducer, CompositeTransducer],
-        tokenizer: DefaultTokenizer,
+        tokenizer: Tokenizer,
     ):
         self._transducer = transducer
         self._tokenizer = tokenizer


### PR DESCRIPTION
Changes the signature of `make_g2p()`: the `tok_lang` argument is now deprecated, tokenization is now the default, and the new name-only arguments `tokenize` and `custom_tokenizer` are now used to select specific behaviours in those corner cases where the default is not right for an app.

Fixes: #252

BREAKING CHANGE: modifies the default behaviour of make_g2p. This is minor, though, and will be a bug fix for most apps, with the exception of ReadAlongs/Studio.