### PR TITLE
perf: optimize lexicon in-memory footprint

### DIFF
--- a/g2p/mappings/utils.py
+++ b/g2p/mappings/utils.py
@@ -526,12 +526,14 @@ def parse_alignment(alignment: str, delimiter="") -> Tuple[str, Tuple]:
     return ("".join(chars), tuple(mappings))
 
 
+# The joiner between key and value must be 0 so that it sorts before all
+# characters and thus won't break bisect_left()
 _JOINER = "\0"
 
 
 def find_alignment(alignments: List[str], word: str) -> Tuple:
     """Given a sorted list of (word, alignment), find word and return its parsed alignment."""
-    i = bisect_left(alignments, word, key=lambda x: x.split(_JOINER, maxsplit=1)[0])
+    i = bisect_left(alignments, word)
     if i != len(alignments):
         k, v = alignments[i].split(_JOINER, maxsplit=1)
         if k == word:

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -18,10 +18,10 @@ from g2p.mappings.langs.utils import is_arpabet, is_panphon
 from g2p.mappings.tokenizer import Tokenizer
 from g2p.mappings.utils import (
     compose_indices,
+    get_alignment_output_tuple,
     is_ipa,
     normalize,
     normalize_with_indices,
-    parse_alignment,
     unicode_escape,
 )
 
@@ -807,8 +807,7 @@ class Transducer:
             tg.edges = []
             tg.output_string = ""
         else:
-            (word, alignment) = parse_alignment(alignment_str, self.out_delimiter)
-            assert word == to_convert
+            alignment = get_alignment_output_tuple(alignment_str, self.out_delimiter)
             tg.output_string = ""
             edges: List[Tuple[int, int]] = []
             in_pos = 0

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -21,6 +21,7 @@ from g2p.mappings.utils import (
     is_ipa,
     normalize,
     normalize_with_indices,
+    parse_alignment,
     unicode_escape,
 )
 
@@ -801,11 +802,13 @@ class Transducer:
         tg = TransductionGraph(to_convert)
         if not self.case_sensitive:
             to_convert = to_convert.lower()
-        alignment = self.mapping.alignments.get(to_convert, ())
-        if not alignment:
+        alignment_str = self.mapping.alignments.get(to_convert, ())
+        if not alignment_str:
             tg.edges = []
             tg.output_string = ""
         else:
+            (word, alignment) = parse_alignment(alignment_str, self.out_delimiter)
+            assert word == to_convert
             tg.output_string = ""
             edges: List[Tuple[int, int]] = []
             in_pos = 0

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -18,7 +18,7 @@ from g2p.mappings.langs.utils import is_arpabet, is_panphon
 from g2p.mappings.tokenizer import Tokenizer
 from g2p.mappings.utils import (
     compose_indices,
-    get_alignment_output_tuple,
+    find_alignment,
     is_ipa,
     normalize,
     normalize_with_indices,
@@ -802,12 +802,11 @@ class Transducer:
         tg = TransductionGraph(to_convert)
         if not self.case_sensitive:
             to_convert = to_convert.lower()
-        alignment_str = self.mapping.alignments.get(to_convert, ())
-        if not alignment_str:
+        alignment = find_alignment(self.mapping.alignments, to_convert)
+        if not alignment:
             tg.edges = []
             tg.output_string = ""
         else:
-            alignment = get_alignment_output_tuple(alignment_str, self.out_delimiter)
             tg.output_string = ""
             edges: List[Tuple[int, int]] = []
             in_pos = 0

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -811,9 +811,7 @@ class Transducer:
             edges: List[Tuple[int, int]] = []
             in_pos = 0
             out_pos = 0
-            # Mappings are flattened to save space
-            for idx in range(0, len(alignment), 2):
-                (n_inputs, outtxt) = alignment[idx : idx + 2]
+            for n_inputs, outtxt in alignment:
                 for i in range(n_inputs):
                     for j in range(len(outtxt)):
                         edges.append((in_pos + i, out_pos + j))


### PR DESCRIPTION
Metric: how much RAM this command uses in ReadAlongs Studio:

    DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload

Results:

     - baseline: eng lexicon stored as Dict[str, Tuple]       RAM: 100.7 MB
       where the tuple value is the parsed alignment
     - optimization 1: change to Dict[str, str] where the     RAM:  72.5 MB
       str value is the raw alignment string
     - failed opt: use a sorted list of tuples                RAM:  75.4 MB
     - optimization 2: change to List[str] with k, v          RAM:  61.9 MB
       joined by "\0", and bisect_left to find elements
     - absolute limit: no lexicon at all (v1.0.20230228)      RAM:  42.9 MB

So the English lexicon required about 60MB RAM in the previous (already optimized!) implementation and now shrinks to about 20MB.

Motivation: this will let us make the ReadAlong Studio web_api backend more memory efficient on our Heroku deployment, where memory is limited to 512MB per dyno.