### PR TITLE
Adjust dependencies based on the Python version

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -1,5 +1,7 @@
 name: Run full matrix Tests before Releases
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ release ]
 jobs:

--- a/g2p/templates/index.html
+++ b/g2p/templates/index.html
@@ -163,9 +163,10 @@
 
 <script src="https://cdn.jsdelivr.net/npm/handsontable@latest/dist/handsontable.full.min.js"></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"
-        integrity="sha256-w9DVlb/Yjkq3lOk0YpBPzeL+FZvaNALjmkJoZQYGc0I="
-        crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.6.2/socket.io.min.js"
+	integrity="sha512-mUWPbwx6PZatai4i3+gevCw6LeuQxcMgnJs/DZij22MZ4JMpqKaEvMq0N9TTArSWEb5sdQ9xH68HMUc30eNPEA=="
+	crossorigin="anonymous"
+	referrerpolicy="no-referrer">
 </script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/echarts/4.2.1/echarts.min.js"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,8 +18,8 @@ text_unidecode
 
 # Python 3.7+ requirements with current packages
 click>=8.1.3; python_version >= "3.7"
-Flask>=2.2.5; python_version >= "3.7"
-werkzeug>=2.2.3; python_version >= "3.7"
+Flask==2.2.5; python_version >= "3.7"
+werkzeug==2.2.3; python_version >= "3.7"
 
 # Python 3.6 requirements due to newer packages not available 3.6
 click>=8.0.4; python_version < "3.7"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,20 +1,27 @@
 openpyxl
-click==8.0.4
 coloredlogs<=14.0
 dnspython>=2.1.0
 eventlet>=0.33.0
 flask-cors>=3.0.9
-Flask>=2.0.0,<=2.1.3
-flask_socketio==4.3.2
 flask-talisman>=0.7.0
+flask_socketio>=4.3.2
 flask-restful>=0.3.9
 networkx>=2.5,<=2.8.4
 panphon>=0.19
-python-engineio==3.14.2 
-python-socketio==4.6.1
+python-engineio>=3.14.2
+python-socketio>=4.6.1
 pyyaml>=5.2
 regex
 requests
 tqdm
 text_unidecode
-werkzeug==2.0.3
+
+# Python 3.7+ requirements with current packages
+click>=8.1.3; python_version >= "3.7"
+Flask>=2.2.5; python_version >= "3.7"
+werkzeug>=2.2.3; python_version >= "3.7"
+
+# Python 3.6 requirements due to newer packages not available 3.6
+click>=8.0.4; python_version < "3.7"
+Flask>=2.0.0,<=2.1.3; python_version < "3.7"
+werkzeug==2.0.3; python_version < "3.7"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,15 +1,13 @@
 openpyxl
+click>=8.0.4
 coloredlogs<=14.0
 dnspython>=2.1.0
 eventlet>=0.33.0
 flask-cors>=3.0.9
 flask-talisman>=0.7.0
-flask_socketio>=4.3.2
 flask-restful>=0.3.9
 networkx>=2.5,<=2.8.4
 panphon>=0.19
-python-engineio>=3.14.2
-python-socketio>=4.6.1
 pyyaml>=5.2
 regex
 requests
@@ -17,11 +15,15 @@ tqdm
 text_unidecode
 
 # Python 3.7+ requirements with current packages
-click>=8.1.3; python_version >= "3.7"
 Flask==2.2.5; python_version >= "3.7"
 werkzeug==2.2.3; python_version >= "3.7"
+flask_socketio>=5.0.0; python_version >= "3.7"
+python-engineio>=4.0.0; python_version >= "3.7"
+python-socketio>=5.0.0; python_version >= "3.7"
 
 # Python 3.6 requirements due to newer packages not available 3.6
-click>=8.0.4; python_version < "3.7"
 Flask>=2.0.0,<=2.1.3; python_version < "3.7"
 werkzeug==2.0.3; python_version < "3.7"
+flask_socketio>=4.3.2; python_version < "3.7"
+python-engineio>=3.14.2; python_version < "3.7"
+python-socketio>=4.6.1; python_version < "3.7"

--- a/run_studio.py
+++ b/run_studio.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python
 
+import sys
+
+if sys.version_info < (3, 7, 0):  # pragma: no cover
+    raise Exception("")
+    sys.exit(
+        "ERROR: While the g2p CLI and library can still run on Python 3.6, "
+        "g2p-studio requires Python 3.7 or more recent.\n"
+        f"You are using {sys.version}.\n"
+        "Please use a newer version of Python."
+    )
+
 from g2p.app import APP, SOCKETIO
 from g2p.log import LOGGER
 


### PR DESCRIPTION
Python 3.6 is now still supported, but only for the CLI and the g2p library module, but not for g2p Studio.

Dependencies can now be updated as needed for Py >= 3.7 when there are CVEs.