### PR TITLE
fix: the egg syntax is deprecated, use the at syntax instead

### DIFF
--- a/requirements/requirements.prod.txt
+++ b/requirements/requirements.prod.txt
@@ -1,1 +1,1 @@
-https://github.com/benoitc/gunicorn/archive/ff58e0c6da83d5520916bc4cc109a529258d76e1.zip#egg=gunicorn==20.1.0
+gunicorn @ git+https://github.com/benoitc/gunicorn@add8a4c951f02a67ca1f81264e5c107fa68e6496


### PR DESCRIPTION
The Heroku build issues this warning:
      DEPRECATION: https://github.com/benoitc/gunicorn/archive/ff58e0c6da83d5520916bc4cc109a529258d76e1.zip#egg=gunicorn==20.1.0 contains an egg fragment with a non-PEP 508 name pip 25.0 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at https://github.com/pypa/pip/issues/11617

So use the current "gunicorn @ git:https://..." syntax instead.

And take the latest version of gunicorn while I'm changing this.