### PR TITLE
fix(deps): lock dnspython to compatible 2.3.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 openpyxl
 click>=8.0.4
 coloredlogs<=14.0
-dnspython>=2.1.0
+dnspython>=2.1.0,<=2.3.0
 eventlet>=0.33.0
 flask-cors>=3.0.9
 flask-talisman>=0.7.0


### PR DESCRIPTION
dnspython 2.4.0 drops requests support so we need <=2.3.0 See https://www.dnspython.org/news/2.4.0/
