### PR TITLE
test: add unit test case mimicking #130 to confirm it works on Windows

### DIFF
--- a/g2p/tests/public/data/fn_unicode.psv
+++ b/g2p/tests/public/data/fn_unicode.psv
@@ -1,2 +1,3 @@
 fn-unicode-font|fn-unicode|qʷi∙qʷi∙diččaq|qʷi·qʷi·diččaq
 fn-unicode-font|fn-unicode|ล|ḥ
+fn-unicode-font|fn-unicode|X   ล ɤ ∛ X|x ᶿ √ ḥ ɣ · x


### PR DESCRIPTION
Indeed, #130 was due to (really annoying) Windows terminal limitations. These extra test cases pass on Windows, confirming it's not a bug in g2p.

