### PR TITLE
feat(schema): update schema generation to include  dialect spec by default

### DIFF
--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -688,8 +688,12 @@ def update_schema(out_dir):
         raise FileExistsError(
             f"Sorry a schema already exists for version {VERSION}. Please bump the minor version number and generate the schema again."
         )
+    json_schema = MappingConfig.model_json_schema()
+    # Add explicit schema dialect for SchemaStore
+    # Note that pydantic actually targets
+    json_schema["$schema"] = "http://json-schema.org/draft-07/schema#"
     with open(schema_path, "w") as f:
-        json.dump(MappingConfig.model_json_schema(), f)
+        json.dump(json_schema, f, indent=2)
 
 
 @click.argument("path", type=click.Path(exists=True, file_okay=True, dir_okay=False))

--- a/g2p/mappings/.schema/g2p-config-schema-2.0.json
+++ b/g2p/mappings/.schema/g2p-config-schema-2.0.json
@@ -1,1 +1,330 @@
-{"$defs": {"MAPPING_TYPE": {"enum": ["mapping", "unidecode", "lexicon"], "title": "MAPPING_TYPE", "type": "string"}, "Mapping": {"additionalProperties": true, "description": "Class for lookup tables", "properties": {"parent_dir": {"anyOf": [{"format": "directory-path", "type": "string"}, {"type": "null"}], "default": null, "title": "Parent Dir"}, "id": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null, "title": "Id"}, "in_lang": {"default": "standalone", "title": "In Lang", "type": "string"}, "out_lang": {"default": "standalone", "title": "Out Lang", "type": "string"}, "language_name": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null, "title": "Language Name"}, "display_name": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null, "title": "Display Name"}, "as_is": {"anyOf": [{"type": "boolean"}, {"type": "null"}], "default": null, "title": "As Is"}, "case_sensitive": {"default": true, "title": "Case Sensitive", "type": "boolean"}, "escape_special": {"default": false, "title": "Escape Special", "type": "boolean"}, "norm_form": {"allOf": [{"$ref": "#/$defs/NORM_FORM_ENUM"}], "default": "NFD"}, "out_delimiter": {"default": "", "title": "Out Delimiter", "type": "string"}, "reverse": {"default": false, "title": "Reverse", "type": "boolean"}, "rule_ordering": {"allOf": [{"$ref": "#/$defs/RULE_ORDERING_ENUM"}], "default": "as-written"}, "prevent_feeding": {"default": false, "title": "Prevent Feeding", "type": "boolean"}, "type": {"anyOf": [{"$ref": "#/$defs/MAPPING_TYPE"}, {"type": "null"}], "default": null}, "alignments": {"anyOf": [{"type": "string"}, {"items": {"type": "string"}, "type": "array"}, {"type": "null"}], "default": null, "title": "Alignments"}, "authors": {"anyOf": [{"items": {"type": "string"}, "type": "array"}, {"type": "null"}], "default": null, "title": "Authors"}, "abbreviations": {"anyOf": [{"format": "path", "type": "string"}, {"additionalProperties": {"items": {"type": "string"}, "type": "array"}, "type": "object"}, {"type": "null"}], "default": null, "title": "Abbreviations"}, "rules": {"anyOf": [{"format": "path", "type": "string"}, {"items": {"$ref": "#/$defs/Rule"}, "type": "array"}, {"type": "null"}], "default": null, "title": "Rules"}}, "title": "Mapping", "type": "object"}, "NORM_FORM_ENUM": {"enum": ["NFC", "NFD", "NKFC", "NKFD", "none"], "title": "NORM_FORM_ENUM", "type": "string"}, "RULE_ORDERING_ENUM": {"enum": ["as-written", "apply-longest-first"], "title": "RULE_ORDERING_ENUM", "type": "string"}, "Rule": {"properties": {"in": {"title": "In", "type": "string"}, "out": {"title": "Out", "type": "string"}, "context_before": {"default": "", "title": "Context Before", "type": "string"}, "context_after": {"default": "", "title": "Context After", "type": "string"}, "prevent_feeding": {"default": false, "title": "Prevent Feeding", "type": "boolean"}, "match_pattern": {"anyOf": [{"format": "regex", "type": "string"}, {"type": "null"}], "default": null, "title": "Match Pattern"}, "intermediate_form": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null, "title": "Intermediate Form"}, "comment": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null, "title": "Comment"}}, "required": ["in", "out"], "title": "Rule", "type": "object"}}, "description": "This is the format used by g2p for configuring mappings.", "properties": {"mappings": {"items": {"$ref": "#/$defs/Mapping"}, "title": "Mappings", "type": "array"}}, "required": ["mappings"], "title": "MappingConfig", "type": "object"}
+{
+  "$defs": {
+    "MAPPING_TYPE": {
+      "enum": [
+        "mapping",
+        "unidecode",
+        "lexicon"
+      ],
+      "title": "MAPPING_TYPE",
+      "type": "string"
+    },
+    "Mapping": {
+      "additionalProperties": true,
+      "description": "Class for lookup tables",
+      "properties": {
+        "parent_dir": {
+          "anyOf": [
+            {
+              "format": "directory-path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parent Dir"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
+        },
+        "in_lang": {
+          "default": "standalone",
+          "title": "In Lang",
+          "type": "string"
+        },
+        "out_lang": {
+          "default": "standalone",
+          "title": "Out Lang",
+          "type": "string"
+        },
+        "language_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Language Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Display Name"
+        },
+        "as_is": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "As Is"
+        },
+        "case_sensitive": {
+          "default": true,
+          "title": "Case Sensitive",
+          "type": "boolean"
+        },
+        "escape_special": {
+          "default": false,
+          "title": "Escape Special",
+          "type": "boolean"
+        },
+        "norm_form": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/NORM_FORM_ENUM"
+            }
+          ],
+          "default": "NFD"
+        },
+        "out_delimiter": {
+          "default": "",
+          "title": "Out Delimiter",
+          "type": "string"
+        },
+        "reverse": {
+          "default": false,
+          "title": "Reverse",
+          "type": "boolean"
+        },
+        "rule_ordering": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/RULE_ORDERING_ENUM"
+            }
+          ],
+          "default": "as-written"
+        },
+        "prevent_feeding": {
+          "default": false,
+          "title": "Prevent Feeding",
+          "type": "boolean"
+        },
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MAPPING_TYPE"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "alignments": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Alignments",
+          "type": "array"
+        },
+        "alignments_path": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alignments Path"
+        },
+        "authors": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authors"
+        },
+        "abbreviations": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "default": {},
+          "title": "Abbreviations",
+          "type": "object"
+        },
+        "abbreviations_path": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Abbreviations Path"
+        },
+        "rules": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/Rule"
+          },
+          "title": "Rules",
+          "type": "array"
+        },
+        "rules_path": {
+          "anyOf": [
+            {
+              "format": "path",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rules Path"
+        }
+      },
+      "title": "Mapping",
+      "type": "object"
+    },
+    "NORM_FORM_ENUM": {
+      "enum": [
+        "NFC",
+        "NFD",
+        "NKFC",
+        "NKFD",
+        "none"
+      ],
+      "title": "NORM_FORM_ENUM",
+      "type": "string"
+    },
+    "RULE_ORDERING_ENUM": {
+      "enum": [
+        "as-written",
+        "apply-longest-first"
+      ],
+      "title": "RULE_ORDERING_ENUM",
+      "type": "string"
+    },
+    "Rule": {
+      "properties": {
+        "in": {
+          "title": "In",
+          "type": "string"
+        },
+        "out": {
+          "title": "Out",
+          "type": "string"
+        },
+        "context_before": {
+          "default": "",
+          "title": "Context Before",
+          "type": "string"
+        },
+        "context_after": {
+          "default": "",
+          "title": "Context After",
+          "type": "string"
+        },
+        "prevent_feeding": {
+          "default": false,
+          "title": "Prevent Feeding",
+          "type": "boolean"
+        },
+        "match_pattern": {
+          "anyOf": [
+            {
+              "format": "regex",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Match Pattern"
+        },
+        "intermediate_form": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Intermediate Form"
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Comment"
+        }
+      },
+      "required": [
+        "in",
+        "out"
+      ],
+      "title": "Rule",
+      "type": "object"
+    }
+  },
+  "description": "This is the format used by g2p for configuring mappings.",
+  "properties": {
+    "mappings": {
+      "items": {
+        "$ref": "#/$defs/Mapping"
+      },
+      "title": "Mappings",
+      "type": "array"
+    }
+  },
+  "required": [
+    "mappings"
+  ],
+  "title": "MappingConfig",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}


### PR DESCRIPTION
SchemaStore wants the $schema key to be populated, but this is not done by default by pydantic. unfortunately pydantic also targets a different jsonschema dialect than the one recommended by SchemaStore - I'll check to see if this is acceptable.