### PR TITLE
ci: one CI run on push should use the minimum Python, 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.7"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
We don't run the full matrix on push or PR, only on release, but we should have at least one part of the default CI workflow that runs on every push using Python 3.7, or whatever to minimum required version is when that changes.