### PR TITLE
build: dev dependencies should include test dependencies

### DIFF
--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -6,3 +6,4 @@ mypy>=1.4.1
 mypy>=1.5.1; python_version >= "3.8"
 pre-commit>=2.6.0
 types-PyYAML
+-r requirements.test.txt


### PR DESCRIPTION
This is to fix a kind of annoying gotcha, where you install the package and its dev dependencies, but the tests still can't run.