### PR TITLE
fix: remove werkzeug lock since it is no longer necessary

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,7 +15,6 @@ tqdm
 text_unidecode
 
 Flask==2.2.5
-werkzeug==2.2.3
 flask_socketio>=5.0.0
 python-engineio>=4.0.0
 python-socketio>=5.0.0


### PR DESCRIPTION
we had locked it to an older version when we were using a flask-socketio that was not compatible with the latest werkzeug, but we bumped that now so we no longer need this, and keeping it makes dependabot unhappy so remove it.
