### PR TITLE
perf: only create APP when it is really needed

### DIFF
--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -17,7 +17,6 @@ from networkx import has_path
 from g2p import make_g2p, make_tokenizer
 from g2p._version import VERSION
 from g2p.api import update_docs
-from g2p.app import APP
 from g2p.exceptions import InvalidLanguageCode, MappingMissing, NoPath
 from g2p.log import LOGGER
 from g2p.mappings import MAPPINGS_AVAILABLE, Mapping, MappingConfig
@@ -57,6 +56,8 @@ if "pytest" not in sys.modules:  # pragma: no cover
 
 def create_app():
     """Return the flask app for g2p"""
+    from g2p.app import APP
+
     return APP
 
 

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -20,9 +20,12 @@ from unittest import IsolatedAsyncioTestCase, main
 
 from playwright.async_api import async_playwright
 
-from g2p.app import APP, SOCKETIO
+from g2p.app import SOCKETIO
+from g2p.cli import create_app
 from g2p.log import LOGGER
 from g2p.tests.public.data import load_public_test_data
+
+APP = create_app()  # instead of importing APP, we use create_app, just to exercise it.
 
 
 class StudioTest(IsolatedAsyncioTestCase):
@@ -89,7 +92,6 @@ class StudioTest(IsolatedAsyncioTestCase):
             self.assertEqual(await page.locator("#link-0").count(), 0)
 
     async def test_langs(self):
-
         langs_to_test = load_public_test_data()
         # Doing the whole test set takes a long time, so let's use a 10% random sample,
         # knowing that all cases always get exercised in test_cli.py and test_langs.py.


### PR DESCRIPTION
This speeds up g2p -h by a couple seconds on my machine.

It continues to bother me that `g2p -h` takes about 7 seconds, now 5 seconds with this PR. It should be sub-second, but it's taking refactoring I don't think we want to do it. However, this small patch is a first step.