### PR TITLE
Remove the Flask app from the CLI to speed it up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,28 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false # too many upload errors to keep "true"
+      - name: Make sure the CLI stays fast
+        id: cli-load-time
+        run: |
+          PYTHONPROFILEIMPORTTIME=1 g2p -h 2> importtime.txt > /dev/null
+          CLI_LOAD_TIME="$((/usr/bin/time --format=%E g2p -h > /dev/null) 2>&1)"
+          echo "CLI load time: $CLI_LOAD_TIME"
+          cat importtime.txt
+          echo "CLI load time: $CLI_LOAD_TIME" > import-message.txt
+          echo "PR head ${{ github.event.pull_request.head.sha }}" >> import-message.txt
+          echo "Imports that take more than 0.1 s:" >> import-message.txt
+          grep -E 'cumulative|[0-9]{6}' importtime.txt >> import-message.txt
+          if [[ "$CLI_LOAD_TIME" > "0:01.00" ]]; then \
+            echo "ERROR: g2p --help is too slow."; \
+            echo "Please run 'PYTHONPROFILEIMPORTTIME=1 g2p -h 2> importtime.txt; tuna importtime.txt' and tuck away expensive imports so that the CLI doesn't load them until it uses them."; \
+            false; \
+          fi
+      - name: Report help speed in PR
+        if: github.event_name == 'pull_request'
+        uses: mshick/add-pr-comment@v2
+        with:
+          preformatted: true
+          message-path: import-message.txt
 
   test-on-windows:
     # Make sure stuff stays compatible with Windows by testing there too.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           echo "CLI load time: $CLI_LOAD_TIME" > import-message.txt
           echo "PR head ${{ github.event.pull_request.head.sha }}" >> import-message.txt
           echo "Imports that take more than 0.1 s:" >> import-message.txt
-          grep -E 'cumulative|[0-9]{6}' importtime.txt >> import-message.txt
+          grep -E 'cumulative|[0-9]{6} ' importtime.txt >> import-message.txt
           if [[ "$CLI_LOAD_TIME" > "0:01.00" ]]; then \
             echo "ERROR: g2p --help is too slow."; \
             echo "Please run 'PYTHONPROFILEIMPORTTIME=1 g2p -h 2> importtime.txt; tuna importtime.txt' and tuck away expensive imports so that the CLI doesn't load them until it uses them."; \

--- a/g2p/__init__.py
+++ b/g2p/__init__.py
@@ -23,8 +23,8 @@ Basic Usage:
 from typing import Dict, Optional, Tuple, Union
 
 import g2p.deprecation
-from g2p.constants import BaseTokenizer, BaseTransducer
 from g2p.exceptions import InvalidLanguageCode, NoPath
+from g2p.types import BaseTokenizer, BaseTransducer
 
 _g2p_cache: Dict[Tuple[str, str, Optional[str], bool, int], BaseTransducer] = {}
 

--- a/g2p/__init__.py
+++ b/g2p/__init__.py
@@ -20,12 +20,13 @@ Basic Usage:
     from g2p import get_arpabet_langs
     LANGS, LANG_NAMES = get_arpabet_langs()
 """
-from typing import Optional, Union
+from typing import Dict, Optional, Tuple, Union
 
 import g2p.deprecation
+from g2p.constants import BaseTokenizer, BaseTransducer
 from g2p.exceptions import InvalidLanguageCode, NoPath
 
-_g2p_cache = {}
+_g2p_cache: Dict[Tuple[str, str, Optional[str], bool, int], BaseTransducer] = {}
 
 
 def make_g2p(  # noqa: C901
@@ -34,7 +35,7 @@ def make_g2p(  # noqa: C901
     tok_lang: Optional[str] = None,  # DEPRECATED
     *,
     tokenize: bool = True,
-    custom_tokenizer=None,
+    custom_tokenizer: Optional[BaseTokenizer] = None,
 ):
     """Make a g2p Transducer for mapping text from in_lang to out_lang via the
     shortest path between them.

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import List, Tuple
 
 import click
-from flask.cli import FlaskGroup
 
 from g2p import make_g2p, make_tokenizer
 from g2p._version import VERSION
@@ -112,7 +111,7 @@ def parse_from_or_to_lang_spec(lang_spec):
 
 
 @click.version_option(version=VERSION, prog_name="g2p")
-@click.group(cls=FlaskGroup, create_app=create_app, context_settings=CONTEXT_SETTINGS)
+@click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
     """Management script for G2P"""
 

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -32,13 +32,6 @@ if "pytest" not in sys.modules:  # pragma: no cover
         sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf8")
 
 
-def create_app():
-    """Return the flask app for g2p"""
-    from g2p.app import APP
-
-    return APP
-
-
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -17,7 +17,6 @@ from networkx import has_path
 from g2p import make_g2p, make_tokenizer
 from g2p._version import VERSION
 from g2p.api import update_docs
-from g2p.app import APP
 from g2p.exceptions import InvalidLanguageCode, MappingMissing, NoPath
 from g2p.log import LOGGER
 from g2p.mappings import MAPPINGS_AVAILABLE, Mapping, MappingConfig
@@ -57,6 +56,8 @@ if "pytest" not in sys.modules:  # pragma: no cover
 
 def create_app():
     """Return the flask app for g2p"""
+    from g2p.app import APP
+
     return APP
 
 

--- a/g2p/constants.py
+++ b/g2p/constants.py
@@ -1,8 +1,8 @@
 """
 This file is for constants that can be initialized without any (expensive) dependencies.
 """
+
 import os
-from abc import ABC, abstractmethod
 
 DISTANCE_METRICS = [
     "weighted_feature_edit_distance",
@@ -16,28 +16,3 @@ DISTANCE_METRICS = [
 LANGS_DIR = os.path.join(os.path.dirname(__file__), "mappings", "langs")
 LANGS_FILE_NAME = "langs.json.gz"
 NETWORK_FILE_NAME = "network.json.gz"
-
-
-class BaseTransducer(ABC):
-    """Base class to typecheck transducers without having to import them."""
-
-    @abstractmethod
-    def __call__(self, to_convert: str):
-        """Transduce to_convert."""
-
-
-class BaseTransductionGraph(ABC):
-    """Base class to typecheck transduction graphs without having to import them."""
-
-    @property
-    @abstractmethod
-    def tiers(self):
-        """A list of BaseTransductionGraph objects for each tier in the graph."""
-
-
-class BaseTokenizer(ABC):
-    """Base class to typecheck tokenizers without having to import them."""
-
-    @abstractmethod
-    def tokenize_text(self, text):
-        """Tokenize text."""

--- a/g2p/constants.py
+++ b/g2p/constants.py
@@ -1,0 +1,17 @@
+"""
+This file is for constants that can be initialized without any (expensive) dependencies.
+"""
+import os
+
+DISTANCE_METRICS = [
+    "weighted_feature_edit_distance",
+    "hamming_feature_edit_distance",
+    "feature_edit_distance",
+    "dolgo_prime_distance",
+    "fast_levenshtein_distance",
+    "levenshtein_distance",
+]
+
+LANGS_DIR = os.path.join(os.path.dirname(__file__), "mappings", "langs")
+LANGS_FILE_NAME = "langs.json.gz"
+NETWORK_FILE_NAME = "network.json.gz"

--- a/g2p/constants.py
+++ b/g2p/constants.py
@@ -23,7 +23,7 @@ class BaseTransducer(ABC):
 
     @abstractmethod
     def __call__(self, to_convert: str):
-        pass
+        """Transduce to_convert."""
 
 
 class BaseTransductionGraph(ABC):
@@ -32,7 +32,7 @@ class BaseTransductionGraph(ABC):
     @property
     @abstractmethod
     def tiers(self):
-        pass
+        """A list of BaseTransductionGraph objects for each tier in the graph."""
 
 
 class BaseTokenizer(ABC):
@@ -40,4 +40,4 @@ class BaseTokenizer(ABC):
 
     @abstractmethod
     def tokenize_text(self, text):
-        pass
+        """Tokenize text."""

--- a/g2p/constants.py
+++ b/g2p/constants.py
@@ -2,6 +2,7 @@
 This file is for constants that can be initialized without any (expensive) dependencies.
 """
 import os
+from abc import ABC, abstractmethod
 
 DISTANCE_METRICS = [
     "weighted_feature_edit_distance",
@@ -15,3 +16,28 @@ DISTANCE_METRICS = [
 LANGS_DIR = os.path.join(os.path.dirname(__file__), "mappings", "langs")
 LANGS_FILE_NAME = "langs.json.gz"
 NETWORK_FILE_NAME = "network.json.gz"
+
+
+class BaseTransducer(ABC):
+    """Base class to typecheck transducers without having to import them."""
+
+    @abstractmethod
+    def __call__(self, to_convert: str):
+        pass
+
+
+class BaseTransductionGraph(ABC):
+    """Base class to typecheck transduction graphs without having to import them."""
+
+    @property
+    @abstractmethod
+    def tiers(self):
+        pass
+
+
+class BaseTokenizer(ABC):
+    """Base class to typecheck tokenizers without having to import them."""
+
+    @abstractmethod
+    def tokenize_text(self, text):
+        pass

--- a/g2p/mappings/create_ipa_mapping.py
+++ b/g2p/mappings/create_ipa_mapping.py
@@ -17,6 +17,7 @@ from typing import Iterable, List, Tuple
 
 from tqdm import tqdm
 
+from g2p.constants import DISTANCE_METRICS
 from g2p.log import LOGGER
 from g2p.mappings import Mapping
 from g2p.mappings.langs.utils import getPanphonDistanceSingleton
@@ -66,16 +67,6 @@ def process_characters(inv, is_xsampa=False):
 #
 #
 ###################################
-
-
-DISTANCE_METRICS = [
-    "weighted_feature_edit_distance",
-    "hamming_feature_edit_distance",
-    "feature_edit_distance",
-    "dolgo_prime_distance",
-    "fast_levenshtein_distance",
-    "levenshtein_distance",
-]
 
 
 def get_distance_method(dst, distance: str):

--- a/g2p/mappings/langs/__init__.py
+++ b/g2p/mappings/langs/__init__.py
@@ -7,12 +7,11 @@ import os
 
 import networkx
 
+from g2p.constants import LANGS_DIR, LANGS_FILE_NAME, NETWORK_FILE_NAME
 from g2p.log import LOGGER
 
-LANGS_DIR = os.path.dirname(__file__)
-LANGS_FILE_NAME = "langs.json.gz"
+assert LANGS_DIR == os.path.dirname(__file__)
 LANGS_PKL = os.path.join(LANGS_DIR, LANGS_FILE_NAME)
-NETWORK_FILE_NAME = "network.json.gz"
 LANGS_NWORK_PATH = os.path.join(LANGS_DIR, NETWORK_FILE_NAME)
 
 

--- a/g2p/mappings/tokenizer.py
+++ b/g2p/mappings/tokenizer.py
@@ -10,12 +10,12 @@ from typing import List
 
 from networkx.exception import NetworkXError
 
-from g2p.constants import BaseTokenizer
 from g2p.exceptions import MappingMissing
 from g2p.log import LOGGER
 from g2p.mappings import Mapping
 from g2p.mappings.langs import LANGS_NETWORK
 from g2p.mappings.utils import get_unicode_category, is_ipa, merge_if_same_label
+from g2p.types import BaseTokenizer
 
 
 class Tokenizer(BaseTokenizer):

--- a/g2p/mappings/tokenizer.py
+++ b/g2p/mappings/tokenizer.py
@@ -10,6 +10,7 @@ from typing import List
 
 from networkx.exception import NetworkXError
 
+from g2p.constants import BaseTokenizer
 from g2p.exceptions import MappingMissing
 from g2p.log import LOGGER
 from g2p.mappings import Mapping
@@ -17,7 +18,7 @@ from g2p.mappings.langs import LANGS_NETWORK
 from g2p.mappings.utils import get_unicode_category, is_ipa, merge_if_same_label
 
 
-class Tokenizer:
+class Tokenizer(BaseTokenizer):
     """Base class for all g2p tokenizers; implements the default tokenizing behaviour.
 
     By default, a token is defined as a sequence of letters, numbers and

--- a/g2p/tests/test_indices.py
+++ b/g2p/tests/test_indices.py
@@ -7,7 +7,7 @@
 from unicodedata import normalize
 from unittest import TestCase, main
 
-from g2p import LOGGER
+from g2p.log import LOGGER
 from g2p.mappings import Mapping
 from g2p.transducer import Transducer
 

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -20,9 +20,12 @@ from unittest import IsolatedAsyncioTestCase, main
 
 from playwright.async_api import async_playwright
 
-from g2p.app import APP, SOCKETIO
+from g2p.app import SOCKETIO
+from g2p.cli import create_app
 from g2p.log import LOGGER
 from g2p.tests.public.data import load_public_test_data
+
+APP = create_app()  # instead of importing APP, we use create_app, just to exercise it.
 
 
 class StudioTest(IsolatedAsyncioTestCase):
@@ -89,7 +92,6 @@ class StudioTest(IsolatedAsyncioTestCase):
             self.assertEqual(await page.locator("#link-0").count(), 0)
 
     async def test_langs(self):
-
         langs_to_test = load_public_test_data()
         # Doing the whole test set takes a long time, so let's use a 10% random sample,
         # knowing that all cases always get exercised in test_cli.py and test_langs.py.

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -20,12 +20,9 @@ from unittest import IsolatedAsyncioTestCase, main
 
 from playwright.async_api import async_playwright
 
-from g2p.app import SOCKETIO
-from g2p.cli import create_app
+from g2p.app import APP, SOCKETIO
 from g2p.log import LOGGER
 from g2p.tests.public.data import load_public_test_data
-
-APP = create_app()  # instead of importing APP, we use create_app, just to exercise it.
 
 
 class StudioTest(IsolatedAsyncioTestCase):

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -11,7 +11,6 @@ from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Union
 
 import text_unidecode
 
-from g2p.constants import BaseTokenizer, BaseTransducer, BaseTransductionGraph
 from g2p.log import LOGGER
 from g2p.mappings import MAPPING_TYPE, Mapping
 from g2p.mappings.langs.utils import is_arpabet, is_panphon
@@ -25,6 +24,7 @@ from g2p.mappings.utils import (
     strip_index_notation,
     unicode_escape,
 )
+from g2p.types import BaseTokenizer, BaseTransducer, BaseTransductionGraph
 
 # Avoid TypeError in Python < 3.7 (see
 # https://stackoverflow.com/questions/6279305/typeerror-cannot-deepcopy-this-pattern-object)

--- a/g2p/transducer/__init__.py
+++ b/g2p/transducer/__init__.py
@@ -11,10 +11,10 @@ from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Union
 
 import text_unidecode
 
+from g2p.constants import BaseTokenizer, BaseTransducer, BaseTransductionGraph
 from g2p.log import LOGGER
 from g2p.mappings import MAPPING_TYPE, Mapping
 from g2p.mappings.langs.utils import is_arpabet, is_panphon
-from g2p.mappings.tokenizer import Tokenizer
 from g2p.mappings.utils import (
     Rule,
     compose_indices,
@@ -83,7 +83,7 @@ def normalize_edges(
     return list(OrderedDict.fromkeys((i, j) for i, j in edges))
 
 
-class TransductionGraph:
+class TransductionGraph(BaseTransductionGraph):
     """This is the object returned after performing a transduction using a Transducer.
 
     Each TransductionGraph must be initialized with an input string.
@@ -407,7 +407,7 @@ class TransductionGraph:
         return self
 
 
-class Transducer:
+class Transducer(BaseTransducer):
     """This is the fundamental class for performing conversions in the g2p library.
 
     Each Transducer must be initialized with a Mapping object. The Transducer
@@ -1119,7 +1119,7 @@ class CompositeTransductionGraph(TransductionGraph):
             tier.clear_debugger()
 
 
-class CompositeTransducer:
+class CompositeTransducer(BaseTransducer):
     """This class combines Transducer objects to form a CompositeTransducer object.
 
     Attributes:
@@ -1185,7 +1185,7 @@ class CompositeTransducer:
             return result
 
 
-class TokenizingTransducer:
+class TokenizingTransducer(BaseTransducer):
     """This class combines tokenization and transduction.
 
     This is particularly useful for lexicon mappings, which cannot
@@ -1199,7 +1199,7 @@ class TokenizingTransducer:
     def __init__(
         self,
         transducer: Union[Transducer, CompositeTransducer],
-        tokenizer: Tokenizer,
+        tokenizer: BaseTokenizer,
     ):
         self._transducer = transducer
         self._tokenizer = tokenizer
@@ -1266,7 +1266,7 @@ class TokenizingTransducer:
 
 
 def preserve_case(
-    tg: TransductionGraph, case_equivalencies: Dict[str, str] = None
+    tg: TransductionGraph, case_equivalencies: Optional[Dict[str, str]] = None
 ) -> TransductionGraph:
     if case_equivalencies is None:
         case_equivalencies = {}

--- a/g2p/types.py
+++ b/g2p/types.py
@@ -1,0 +1,31 @@
+"""
+This file is for abstract type definitions that can be initialized without any
+(expensive) dependencies.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class BaseTransducer(ABC):
+    """Base class to typecheck transducers without having to import them."""
+
+    @abstractmethod
+    def __call__(self, to_convert: str):
+        """Transduce to_convert."""
+
+
+class BaseTransductionGraph(ABC):
+    """Base class to typecheck transduction graphs without having to import them."""
+
+    @property
+    @abstractmethod
+    def tiers(self):
+        """A list of BaseTransductionGraph objects for each tier in the graph."""
+
+
+class BaseTokenizer(ABC):
+    """Base class to typecheck tokenizers without having to import them."""
+
+    @abstractmethod
+    def tokenize_text(self, text):
+        """Tokenize text."""


### PR DESCRIPTION
This is a pretty significant refactoring effort to move all expensive imports out of two places:
 - `g2p/__init__.py`: just importing `g2p` should not trigger loading and importing everything
 - `g2p/cli.py`: just calling `g2p -h` or `g2p cmd -h` should not trigger loading and importing everything

In both cases, the imports are tucked away inside the functions that need them.

However, we have constants and interfaces we need higher up, so I moved those to a new `g2p/constants.py` file. It's not super elegant, but I think it's at least a partial design improvement: instead of making a top-level module need a deeper one just for its constants or its class definition for typing, I moved them into a lightweight file that both import. This is definitely up for discussion and potential improvements.

But... `g2p -h` now takes just 0.9 seconds on my machine, and a mere 0.05 seconds in the CI run that just finished a few minutes ago.