### PR TITLE
fix(deps): lock numpy<2 because 2.0.0 is coming and has breaking changes

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,6 +7,7 @@ flask-cors>=3.0.9
 flask-talisman>=0.7.0
 flask-restful>=0.3.9
 networkx>=2.6
+numpy>=1.20.2,<2
 panphon>=0.19
 pyyaml>=5.2
 regex


### PR DESCRIPTION
See: https://pythonspeed.com/articles/numpy-2

When numpy 2.0.0 is actually out, we'll want to test g2p and our other projects against it before allowing it.

