### PR TITLE
Move southern and Northern after East Cree to improve sorting

### DIFF
--- a/g2p/mappings/langs/crj/config-g2p.yaml
+++ b/g2p/mappings/langs/crj/config-g2p.yaml
@@ -1,5 +1,5 @@
 <<: &shared
-  language_name: Southern East Cree
+  language_name: East Cree, Southern
 mappings:
   - display_name: Northern East Cree Equivalencies
     in_lang: crj

--- a/g2p/mappings/langs/crl/config-g2p.yaml
+++ b/g2p/mappings/langs/crl/config-g2p.yaml
@@ -1,5 +1,5 @@
 <<: &shared
-  language_name: Northern East Cree
+  language_name: East Cree, Northern
 mappings:
   - display_name: Northern East Cree Equivalencies
     in_lang: crl


### PR DESCRIPTION
Per community request some months ago.

Result in Studio-Web:
![image](https://github.com/roedoejet/g2p/assets/33264708/316ff583-7fd4-4886-89ec-d3fe4cf01108)
