### PR TITLE
Move to the current stable black release. 23.x

### DIFF
--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -1,4 +1,4 @@
-black~=22.0
+black~=23.0
 flake8>=4.0.1
 gitlint-core==0.17.0
 isort>=5.10.1


### PR DESCRIPTION
The code is already compliant with that format, but folks will have to redo `pip install -r requirements/requirements.dev.txt` so future code continues to be compliant.