### PR TITLE
docs: minor improvements to g2p manual

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -30,4 +30,5 @@ A Mapping object is a list of defined rules. A `Rule` has the following permitte
     options:
         show_root_heading: true
         show_source: false
-        heading_level: 4
+        heading_level: 3
+        members_order: source

--- a/docs/start.md
+++ b/docs/start.md
@@ -8,6 +8,6 @@ comments: true
 
 ### What is G2P?
 
-The initial version of this package was developed by [Patrick Littell](https://github.com/littell) and was developed in order to allow for g2p from community orthographies to IPA and back again in [ReadAlong-Studio](https://github.com/dhdaines/ReadAlong-Studio). We decided to then pull out the g2p mechanism from [Convertextract](https://github.com/roedoejet/convertextract) which allows transducer relations to be declared in CSV files, and turn it into its own library - here it is!
+The initial version of this package was developed by [Patrick Littell](https://github.com/littell) and was developed in order to allow for g2p from community orthographies to IPA and back again in [ReadAlong-Studio](https://github.com/ReadAlongs/Studio). We decided to then pull out the g2p mechanism from [Convertextract](https://github.com/roedoejet/convertextract) which allows transducer relations to be declared in CSV files, and some g2p functionality from ReadAlong-Studio, and merge them into a stand-alone g2p library - here it is!
 
 This website has the technical documentation for G2P, but we've also written a [7-part blog series](https://blog.mothertongues.org/g2p-background/) if you want a more thorough introduction to why G2P exists and what you can use it for.


### PR DESCRIPTION
g2p.mappings.Rule documentation:
 - show the fields in the logical order with "members_order: source"
 - show the fields in their normal case rather than all caps with "heading_level: 3" instead of 4

correct a minor detail in the background description of the project.

