### PR TITLE
Fully revamp the release workflow, with PEP440 versions and publication triggered by a tag push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 name: Deploy docs
 on:
+  workflow_call:
   push:
     branches:
       - main
@@ -30,3 +31,8 @@ jobs:
         run: |
           mkdocs build
           mike deploy --push --update-aliases latest
+      - name: Store the docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: latest-docs
+          path: site/

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,36 +1,131 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# To create a release:
+#  - update the version number in g2p/_version.py
+#  - commit the changes
+#  - create an annotated tag with the version number, e.g.: git tag -a v2.0.1 -m "v2.0.1"
+#  - push the tag, which will trigger this pythonpublish release workflow
 
-name: Upload Python Package
+name: Publish g2p to PyPI and create a GitHub release
+
 on:
   push:
-    branches: [ release ]
+    tags:
+      - v[0-9]+.**
+
 jobs:
-  deploy:
+  tests:
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit
+
+  build-docs:
+    uses: ./.github/workflows/docs.yml
+    needs: tests
+    secrets: inherit
+
+  build:
     runs-on: ubuntu-latest
+    needs: tests
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # fetch all commits/branches
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - name: Install dependencies
+    - name: Install build tool
+      run: pip install build
+    - name: Build a binary wheel and a source tarball
+      run: python -m build --sdist --wheel
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  github-release:
+    name: Make a signed GitHub release
+    needs:
+      - tests
+      - build
+      - build-docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Update CHANGELOG
+      id: changelog
+      uses: requarks/changelog-action@v1
+      with:
+        token: ${{ github.token }}
+        tag: ${{ github.ref_name }}
+    - name: Create Release
+      uses: ncipollo/release-action@v1.12.0
+      with:
+        allowUpdates: true
+        name: ${{ github.ref_name }}
+        tag: ${{ github.ref_name }}
+        body: ${{ steps.changelog.outputs.changes }}
+        token: ${{ github.token }}
+
+  deploy-docs:
+    runs-on: ubuntu-latest
+    needs:
+      - build-docs
+      - github-release
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+    - name: Download the latest docs
+      uses: actions/download-artifact@v4
+      with:
+        name: latest-docs
+        path: site/
+    - name: Setup doc deploy
       run: |
-        python -m pip install --upgrade pip
-        pip install build twine
-        pip install -e .
-    - name: Install documentation dependencies
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+    - name: Deploy docs with mike 🚀
       run: |
-        pip install -r docs/requirements.txt
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m build --sdist --wheel
-        twine upload dist/*
+        mike deploy --push --update-aliases latest ${{ github.ref_name }} stable
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: github-release
+    environment:
+      name: pypi
+      url: https://pypi.org/p/g2p
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download the distribution packages
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verbose: true
+
+  # Convertextract depends on g2p<2.0, maybe this is no longer relevant?
+  # Or do we want to keep it because eventually convertextract will depend on g2p>=2.0?
+  trigger-convertextract-build:
+    runs-on: ubuntu-latest
+    needs: publish-to-pypi
+    steps:
     - name: trigger convertextract build
       run: |
         curl --location --request POST 'https://api.github.com/repos/roedoejet/convertextract/dispatches' \
@@ -42,28 +137,3 @@ jobs:
           "event_type": "g2p-published",
           "client_payload": {}
         }'
-    - name: Determine tag
-      id: determine_tag
-      run: |
-        echo "TAG_VERSION=$(ls dist/g2p-*.tar.gz | sed -e 's/.*g2p-//' -e 's/.tar.gz.*//')" >> $GITHUB_OUTPUT
-    - name: Bump version and push tag
-      id: tag_version
-      uses: mathieudutour/github-tag-action@v6.1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: ${{ steps.determine_tag.outputs.TAG_VERSION }}
-        create_annotated_tag: true
-    - name: Create a GitHub release
-      uses: ncipollo/release-action@v1
-      with:
-        tag: ${{ steps.tag_version.outputs.new_tag }}
-        name: Release ${{ steps.tag_version.outputs.new_tag }}
-        body: ${{ steps.tag_version.outputs.changelog }}
-    - name: Setup doc deploy
-      run: |
-        git config user.name 'github-actions[bot]'
-        git config user.email 'github-actions[bot]@users.noreply.github.com'
-    - name: Deploy docs with mike 🚀
-      run: |
-        mkdocs build
-        mike deploy --push --update-aliases latest ${{ steps.tag_version.outputs.new_tag }} stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Run all tests
 on:
   - pull_request
   - push
+  - workflow_call
 
 jobs:
   test-all-on-linux:

--- a/g2p/_version.py
+++ b/g2p/_version.py
@@ -1,3 +1,1 @@
-# -*- coding: UTF-8 -*-o
-
-VERSION = "2.0"
+VERSION = "2.0.0"

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -1,6 +1,7 @@
 """
 Command line interface to the g2p system
 """
+
 import io
 import json
 import os
@@ -684,17 +685,21 @@ def update_schema(out_dir):
     # Defer expensive imports
     from g2p.mappings import MappingConfig
 
+    # We should not be changing the schema for patches, so only include major/minor version
+    MAJOR_MINOR_VERSION = ".".join(VERSION.split(".")[:2])
+
     # Determine path
     if out_dir is None:
         schema_path = (
-            Path(LANGS_DIR) / ".." / ".schema" / f"g2p-config-schema-{VERSION}.json"
+            Path(LANGS_DIR) / f"../.schema/g2p-config-schema-{MAJOR_MINOR_VERSION}.json"
         )
     else:
-        schema_path = Path(out_dir) / f"g2p-config-schema-{VERSION}.json"
+        schema_path = Path(out_dir) / f"g2p-config-schema-{MAJOR_MINOR_VERSION}.json"
     # Generate schema
     if schema_path.exists():
         raise FileExistsError(
-            f"Sorry a schema already exists for version {VERSION}. Please bump the minor version number and generate the schema again."
+            f"Sorry a schema already exists for version {MAJOR_MINOR_VERSION}. "
+            "Please bump the minor version number and generate the schema again."
         )
     json_schema = MappingConfig.model_json_schema()
     # Add explicit schema dialect for SchemaStore

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -102,8 +102,10 @@ class CliTest(TestCase):
         self.assertIn("FileExistsError", str(result))
         with tempfile.TemporaryDirectory() as tmpdir:
             result = self.runner.invoke(update_schema, ["-o", tmpdir])
+            MAJOR_MINOR_VERSION = ".".join(VERSION.split(".")[:2])
             with open(
-                Path(tmpdir) / f"g2p-config-schema-{VERSION}.json", encoding="utf8"
+                Path(tmpdir) / f"g2p-config-schema-{MAJOR_MINOR_VERSION}.json",
+                encoding="utf8",
             ) as f:
                 schema = json.load(f)
         for config in tqdm(

--- a/g2p/tests/test_utils.py
+++ b/g2p/tests/test_utils.py
@@ -10,8 +10,10 @@ from collections import defaultdict
 from unittest import TestCase, main
 
 import yaml
+from pep440 import is_canonical
 
 from g2p import get_arpabet_langs
+from g2p._version import VERSION
 from g2p.exceptions import IncorrectFileType, RecursionError
 from g2p.log import LOGGER
 from g2p.mappings import Mapping, utils
@@ -296,6 +298,9 @@ class UtilsTest(TestCase):
         LANGS2, LANG_NAMES2 = get_arpabet_langs()
         self.assertIs(LANGS2, LANGS)
         self.assertIs(LANG_NAMES2, LANG_NAMES)
+
+    def test_version_is_pep440_compliant(self):
+        self.assertTrue(is_canonical(VERSION))
 
 
 if __name__ == "__main__":

--- a/requirements/requirements.test.txt
+++ b/requirements/requirements.test.txt
@@ -1,2 +1,3 @@
 playwright>=1.26.1
 jsonschema>=4.17.3
+pep440>=0.1.2

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,14 @@
 """ Setup for g2p
 """
-import datetime as dt
 from os import path
 
 from setuptools import find_packages, setup
 
-build_no = dt.datetime.today().strftime("%Y%m%d")
-
 # Ugly hack to read the current version number without importing g2p:
-# (works by )
 with open("g2p/_version.py", "r", encoding="utf8") as version_file:
     namespace = {}  # type: ignore
     exec(version_file.read(), namespace)
-    VERSION = namespace["VERSION"] + "." + build_no
+    VERSION = namespace["VERSION"]
 
 this_directory = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
This is currently "disabled" with the real actions being commented out or prefixed with "echo".

I'd like to test this by pushing an actual test tag, but I want code review before I do it, to make sure I correctly disabled the real work while keeping enough for us to see the result.