### PR TITLE
ci: revamp how we publish documentation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,38 +34,38 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 jobs:
- docs:
+  docs:
     # Create latest docs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,5 @@
 name: Deploy docs
 on:
-  workflow_call:
   push:
     branches:
       - main
@@ -29,10 +28,4 @@ jobs:
             git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Deploy docs with mike 🚀
         run: |
-          mkdocs build
-          mike deploy --push --update-aliases latest
-      - name: Store the docs
-        uses: actions/upload-artifact@v4
-        with:
-          name: latest-docs
-          path: site/
+          mike deploy --push --update-aliases dev latest

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -24,20 +24,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    - name: Install build tool
-      run: pip install build
-    - name: Build a binary wheel and a source tarball
-      run: python -m build --sdist --wheel
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install build tool
+        run: pip install build
+      - name: Build a binary wheel and a source tarball
+        run: python -m build --sdist --wheel
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
 
   github-release:
     name: Make a signed GitHub release
@@ -51,58 +51,58 @@ jobs:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for sigstore
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-    - name: Update CHANGELOG
-      id: changelog
-      uses: requarks/changelog-action@v1
-      with:
-        token: ${{ github.token }}
-        tag: ${{ github.ref_name }}
-    - name: Create Release
-      uses: ncipollo/release-action@v1.12.0
-      with:
-        allowUpdates: true
-        name: ${{ github.ref_name }}
-        tag: ${{ github.ref_name }}
-        body: ${{ steps.changelog.outputs.changes }}
-        token: ${{ github.token }}
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v1.2.3
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Update CHANGELOG
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ github.token }}
+          tag: ${{ github.ref_name }}
+      - name: Create Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          allowUpdates: true
+          name: ${{ github.ref_name }}
+          tag: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changes }}
+          token: ${{ github.token }}
 
   deploy-docs:
     runs-on: ubuntu-latest
     needs:
       - github-release
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # fetch all commits/branches
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.8"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-    - name: Install documentation dependencies
-      run: |
-        pip install -r docs/requirements.txt
-    - name: Setup doc deploy
-      run: |
-        git config user.name 'github-actions[bot]'
-        git config user.email 'github-actions[bot]@users.noreply.github.com'
-    - name: Deploy docs with mike 🚀
-      run: |
-        mike deploy --push --update-aliases ${{ github.ref_name }} stable latest
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # fetch all commits/branches
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Install documentation dependencies
+        run: |
+          pip install -r docs/requirements.txt
+      - name: Setup doc deploy
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Deploy docs with mike 🚀
+        run: |
+          mike deploy --push --update-aliases ${{ github.ref_name }} stable latest
 
   publish-to-pypi:
     name: Publish to PyPI
@@ -114,16 +114,16 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
-    - name: Download the distribution packages
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        verbose: true
+      - name: Download the distribution packages
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true
 
   # Convertextract depends on g2p<2.0, maybe this is no longer relevant?
   # Or do we want to keep it because eventually convertextract will depend on g2p>=2.0?
@@ -131,14 +131,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-to-pypi
     steps:
-    - name: trigger convertextract build
-      run: |
-        curl --location --request POST 'https://api.github.com/repos/roedoejet/convertextract/dispatches' \
-        --header 'Accept: application/vnd.github.everest-preview+json' \
-        --header 'Content-Type: application/json' \
-        --header 'Authorization: Bearer ${{ secrets.G2P_PAT }}' \
-        --header 'Content-Type: text/plain' \
-        --data-raw '{
-          "event_type": "g2p-published",
-          "client_payload": {}
-        }'
+      - name: trigger convertextract build
+        run: |
+          curl --location --request POST 'https://api.github.com/repos/roedoejet/convertextract/dispatches' \
+          --header 'Accept: application/vnd.github.everest-preview+json' \
+          --header 'Content-Type: application/json' \
+          --header 'Authorization: Bearer ${{ secrets.G2P_PAT }}' \
+          --header 'Content-Type: text/plain' \
+          --data-raw '{
+            "event_type": "g2p-published",
+            "client_payload": {}
+          }'

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -20,11 +20,6 @@ jobs:
     uses: ./.github/workflows/matrix-tests.yml
     secrets: inherit
 
-  build-docs:
-    uses: ./.github/workflows/docs.yml
-    needs: tests
-    secrets: inherit
-
   build:
     runs-on: ubuntu-latest
     needs: tests
@@ -85,24 +80,29 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     needs:
-      - build-docs
       - github-release
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: gh-pages
-    - name: Download the latest docs
-      uses: actions/download-artifact@v4
+        fetch-depth: 0 # fetch all commits/branches
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        name: latest-docs
-        path: site/
+        python-version: "3.8"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+    - name: Install documentation dependencies
+      run: |
+        pip install -r docs/requirements.txt
     - name: Setup doc deploy
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
     - name: Deploy docs with mike 🚀
       run: |
-        mike deploy --push --update-aliases latest ${{ github.ref_name }} stable
+        mike deploy --push --update-aliases ${{ github.ref_name }} stable latest
 
   publish-to-pypi:
     name: Publish to PyPI


### PR DESCRIPTION
There were several bugs that needed fixing in the docs publication workflow.

New model:
 - versions get published as, e.g., v2.0, with the latest version getting alias stable, and alias latest as long as no further commits are done on main
 - a push to main triggers the update of dev, with alias latest
 - the default is stable, so that docs will default to the documentation of the latest version published to PyPI
 - https://roedoejet.github.io/g2p/latest will show the latest, typically dev
 - https://roedoejet.github.io/g2p/stable and https://roedoejet.github.io/g2p will show the latest stable
 - due to limitations in mkdocs-material, the aliases are not shown in the selector, they only work in URLs.

This PR will require a manual push to gh-pages before it's safe to merge, but afterwards docs updates will be automatic.

