### PR TITLE
build(deps): bump coloredlogs to the latest version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 openpyxl
 click>=8.0.4
-coloredlogs<=14.0
+coloredlogs>=15.0.1
 dnspython>=2.1.0,<=2.3.0
 eventlet>=0.33.0,!=0.36.0
 flask-cors>=3.0.9


### PR DESCRIPTION
We had locked <=14.0 because 14.1, 14.2, 14.3 and 15.0 were broken for us. 15.0.1 fixes the problem we had.

See https://coloredlogs.readthedocs.io/en/latest/changelog.html#release-15-0-1-2021-06-11
