### PR TITLE
fix: make the g2p library tests still run on Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          # Note: this is where we also test that the g2p library still works on 3.7
+          python-version: "3.7"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Once you have the Compiled DB, it is then possible to use the `g2p convert` comm
 You can also run the `g2p Studio` which is a web interface for
 creating custom lookup tables to be used with g2p. To run the `g2p
 Studio` either visit https://g2p-studio.herokuapp.com/ or run it
-locally with `run_studio.py`.
+locally with `python run_studio.py`.
 
 ## API for Developers
 

--- a/g2p/tests/run.py
+++ b/g2p/tests/run.py
@@ -15,7 +15,6 @@ from unittest import TestLoader, TestSuite, TextTestRunner
 
 # Unit tests
 from g2p.log import LOGGER
-from g2p.tests.test_api_resources import ResourceIntegrationTest
 from g2p.tests.test_check_ipa_arpabet import CheckIpaArpabetTest
 from g2p.tests.test_cli import CliTest
 from g2p.tests.test_create_mapping import MappingCreationTest
@@ -33,6 +32,13 @@ from g2p.tests.test_transducer import TransducerTest
 from g2p.tests.test_unidecode_transducer import UnidecodeTransducerTest
 from g2p.tests.test_utils import UtilsTest
 from g2p.tests.test_z_local_config import LocalConfigTest
+
+if sys.version_info >= (3, 8, 0):
+    from g2p.tests.test_api_resources import ResourceIntegrationTest
+
+    API_TEST_CLASSES = [ResourceIntegrationTest]
+else:
+    API_TEST_CLASSES = []
 
 LOADER = TestLoader()
 
@@ -71,10 +77,10 @@ INTEGRATION_TESTS = [
     LOADER.loadTestsFromTestCase(test)
     for test in [
         CliTest,
-        ResourceIntegrationTest,
         DoctorTest,
         ExpensiveDoctorTest,
     ]
+    + API_TEST_CLASSES
 ]
 
 # LocalConfigTest has to get run last, to avoid interactions with other test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,10 @@ api = [
     "jinja2",
 ]
 test = [
-  "g2p[api]",
+  "g2p[api]; python_version >= '3.8'",
   "coverage[toml]>=6.5",
   "playwright>=1.26.1",
   "jsonschema>=4.17.3",
-  "pep440>=0.1.2",
   "httpx",
   # Kind of bogus that we need both httpx and aiohttp, but socketio
   # wants this


### PR DESCRIPTION
All production API code, and API testing code, requires Python 3.7, but the base g2p CLI and library module still support Python 3.7 and need to be testing in CI.

@dhdaines This PR on top of #360 would fix my concerns regarding exercising g2p library tests with Python 3.7