### PR TITLE
ci: make the PR comment optional so dependabot PRs pass CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,7 @@ jobs:
           fi
       - name: Report help speed in PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: mshick/add-pr-comment@v2
         with:
           preformatted: true


### PR DESCRIPTION
Dependabot does not have permission to post PR comments, but that should not make it fail CI.

