### PR TITLE
fix(build): depend on gitlint-core, not gitlint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
   "g2p[test]",
   "black>=23; python_version < '3.8'",
   "black~=24.3; python_version >= '3.8'",
-  "gitlint>=0.17.0",
+  "gitlint-core>=0.17.0",
   "isort>=5.10.1",
   "mypy>=1; python_version < '3.8'",
   "mypy>=1.8.0; python_version >= '3.8'",


### PR DESCRIPTION
From https://jorisroovers.com/gitlint/latest/installation/:
> By default, gitlint is installed with pinned dependencies. To install
> gitlint with looser dependency requirements, only install gitlint-core

We don't want gitlint's pinned requirements to cause trouble, which they did when I tried to install ReadAlongs/Studio in a sandbox where the latest g2p was already installed with .[dev].
