### PR TITLE
A couple of Studio fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
 # in g2p/mappings/.schema!!!
 env:
   SETUPTOOLS_SCM_PRETEND_VERSION: "2.0"
+  G2P_STUDIO_DEBUG: 1
 
 jobs:
   test-all-on-linux:

--- a/g2p/app.py
+++ b/g2p/app.py
@@ -15,7 +15,8 @@ http://localhost:5000/ and the API at http://localhost:5000/api/v1/docs
 
 """
 
-from typing import List, Union
+import os
+from typing import Dict, List, Union
 
 import socketio  # type: ignore
 from networkx import shortest_path  # type: ignore
@@ -47,8 +48,10 @@ from g2p.transducer import (
 DEFAULT_N = 10
 
 TEMPLATES = Jinja2Templates(directory="g2p/templates")
-# FIXME: CORS
-SIO = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+server_args: Dict[str, Union[bool, str]] = {"async_mode": "asgi"}
+if os.getenv("G2P_STUDIO_DEBUG"):
+    server_args["logger"] = server_args["engineio_logger"] = True
+SIO = socketio.AsyncServer(**server_args)
 SIO_APP = socketio.ASGIApp(socketio_server=SIO, socketio_path="/ws/socket.io")
 
 

--- a/g2p/static/custom.js
+++ b/g2p/static/custom.js
@@ -437,23 +437,23 @@ var trackIndex = function() {
 
 var convert = function() {
     // prevent conversion from happening before TABLES, ABBS, and SETTINGS are populated.
-    if (TABLES.length > 0 && ABBS.length > 0) {
-        let index = trackIndex()
-        var input_string = $('#input').val();
-        if (index) {
-            input_string = $('#indexInput').val();
-        }
-        if (input_string) {
-            let mappings = getIncludedMappings()
-            conversionSocket.emit('conversion event', {
-                data: {
-                    index,
-                    input_string,
-                    mappings
-                }
-            });
-        }
+    if (TABLES.length == 0 || ABBS.length == 0)
+        return;
+    let index = trackIndex()
+    var input_string = $('#input').val();
+    if (index) {
+        input_string = $('#indexInput').val();
     }
+    let mappings = getIncludedMappings()
+    // we will still request a conversion if the input is empty (that
+    // way if you delete it you aren't stuck with a phantom output)
+    conversionSocket.emit('conversion event', {
+        data: {
+            index,
+            input_string,
+            mappings
+        }
+    });
 }
 
 document.getElementById('animated-radio').addEventListener('click', function(event) {


### PR DESCRIPTION
One rather important one - we definitely *do not* need to send CORS from the Studio app to accept all origins, this was a (bad) leftover from some example code.  Studio is definitely same-origin and should always be.

One less important one - if you delete all the input, the last character sticks around.  It isn't a problem to request conversion of an empty string so we should allow it to happen.

Also add the G2P_STUDIO_DEBUG environment variable which prints out all the socket.io messages, very useful for debugging.