### PR TITLE
fix: normalize ó in mohawk

### DIFF
--- a/g2p/mappings/langs/moh/moh_equiv.json
+++ b/g2p/mappings/langs/moh/moh_equiv.json
@@ -16,5 +16,6 @@
     {"in": "e:", "out": "é:"},
     {"in": "a:", "out": "á:"},
     {"in": "o:", "out": "ó:"},
+    {"in": "ό", "out": "ó"},
     {"in": ":", "out": ":", "comment": "force the tokenizer to recognize colon as a letter"}
 ]


### PR DESCRIPTION
A minor change where normalizing ó to accommodate different typing inputs