### PR TITLE
docs: add a second PR template, for software and other non-mapping PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,11 @@
 Pull request template for adding a new language
 -----------------------------------------------
 
-*Do not use this for other types of pull requests*
+<!--
+  - Use this template if you are adding a new language or modifying a mapping
+  - For all other PRs, please add  ?expand=1&template=software_pr.md  to the URL above
+    to use the software PR template instead.
+ -->
 
 * **Please check if the PR fulfills these requirements**
 - [ ] Mapping files are added in `g2p/mappings/langs`

--- a/.github/pull_request_template/software_pr.md
+++ b/.github/pull_request_template/software_pr.md
@@ -1,0 +1,36 @@
+<!-- PR template: please provide enough information to guide your reviewers.
+Please read Contributing.md before submitting a PR.  -->
+
+### PR Goal? <!-- Explain the main objective of this PR. -->
+
+
+
+### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->
+
+
+
+### Feedback sought? <!-- What should reviewers focus on in particular? -->
+
+
+
+### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->
+
+
+
+### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->
+
+
+
+### How to test? <!-- Explain how reviewers should test this PR. -->
+
+
+
+### Confidence? <!-- How confident are you that these changes are ready to merge? -->
+
+
+
+### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->
+
+
+
+<!-- Add any other relevant information here -->


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Add a software development oriented PR template to this repo.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

simple agreement

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

Since this repo has a default template and an alternative template, it will be a two step process. To see what it will be like, click on https://github.com/joanise/just-testing/compare/main...dev.gzip-on-ci-all-OSs and then manually add `?expand=1&template=studio_web_pr_template.md`, to accurately reproduce the process I'm suggesting for g2p.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
