### PR TITLE
feat: add logic to auto-delete as_is support in g2p 3

### DIFF
--- a/g2p/mappings/__init__.py
+++ b/g2p/mappings/__init__.py
@@ -16,6 +16,7 @@ import yaml
 from pydantic import BaseModel
 
 from g2p import exceptions
+from g2p._version import version_tuple
 from g2p.log import LOGGER
 from g2p.mappings.langs import _LANGS, _MAPPINGS_AVAILABLE
 from g2p.mappings.langs import __file__ as LANGS_FILE
@@ -160,6 +161,15 @@ class Mapping(_MappingModelDefinition):
                 'is using the deprecated parameter "as_is"; '
                 f"replace `as_is: {self.as_is}` with `rule_ordering: {appropriate_setting.value}`"
             )
+            if version_tuple < (3,):
+                LOGGER.warning(
+                    "as_is support will be removed in the next major version, g2p 3."
+                )
+            else:
+                LOGGER.error("The as_is feature has been removed in version 3.0.0")
+                import sys
+
+                sys.exit(1)
 
         # Sorting must happen before the calculation of PUA intermediate forms for proper indexing
         if self.rule_ordering == RULE_ORDERING_ENUM.apply_longest_first:

--- a/g2p/tests/test_mappings.py
+++ b/g2p/tests/test_mappings.py
@@ -60,7 +60,7 @@ class MappingTest(TestCase):
     def test_json_map(self):
         json_map = Mapping(
             rules=self.json_map["map"],
-            **{k: v for k, v in self.json_map.items() if k != "map"}
+            **{k: v for k, v in self.json_map.items() if k != "map"},
         )
         self.assertEqual(len(json_map.rules), 34)
         # This is a very old version of the config, I'm not even sure these tests should be in here at all.
@@ -83,6 +83,8 @@ class MappingTest(TestCase):
     def test_as_is(self):
         """
         Test deprecated config: as_is.
+
+        This will fail when we release g2p 3.0.0, at which point we can just delete this test.
         """
 
         # explicitly set as_is=False


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

`as_is` has been deprecated for a long time, but we didn't declare when it would be removed. Let this be that declaration.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Fixes #374

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity check

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

was already tested

### How to test? <!-- Explain how reviewers should test this PR. -->

If you want to see it fail, change `version_tuple < (3,):` to `< (2,)`, that will make the as_is unit test fail now, which should get deleted when we release 3.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
