### PR TITLE
fix(deps): pin panphon to 0.19-0.20 as 0.21 breaks many things

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "coloredlogs>=15.0.1",
     "networkx>=2.6",
     "openpyxl",
-    "panphon>=0.19",
+    "panphon>=0.19,<0.21",
     "pydantic>=2.4",
     "pyyaml>=5.2",
     "regex",


### PR DESCRIPTION
It gives different output and also causes Python 3.8 to crash, as detailed in https://github.com/dmort27/panphon/pull/57

Fixes: #386 