### PR TITLE
fix(ci): remove stale job dependency in pythonpublish workflow

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -45,7 +45,6 @@ jobs:
       - tests
       - matrix-tests
       - build
-      - build-docs
     runs-on: ubuntu-latest
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
@@ -104,7 +103,9 @@ jobs:
   publish-to-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: github-release
+    needs:
+      - github-release
+      - deploy-docs
     environment:
       name: pypi
       url: https://pypi.org/p/g2p

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,11 +84,8 @@ jobs:
   test-on-windows:
     # Make sure stuff stays compatible with Windows by testing there too.
     runs-on: windows-latest
-    if: ${{ !contains(github.event.head_commit.message, '#no-ci') }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Fix the python publish workflow so we can publish 2.1.0

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Bug in the workflow that made yesterday's attempt at 2.1.0 fail.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

nope

### How to test? <!-- Explain how reviewers should test this PR. -->

Would require forking and removing the real work from this, so not easily. I'm confident in the patch, but if it breaks again we'll just have to try once more. At least we know nothing goes to PyPI unless everything else succeeds.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

High.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

yup...

<!-- Add any other relevant information here -->
