### PR TITLE
Two small changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,19 +17,19 @@ repos:
         entry: isort
         language: system
         types: [python]
-        stages: [commit]
+        stages: [pre-commit]
     -   id: black
         name: black
         entry: black
         language: system
         types: [python]
-        stages: [commit]
+        stages: [pre-commit]
     -   id: mypy
         name: mypy
         entry: mypy
         language: system
         types: [python]
-        stages: [commit]
+        stages: [pre-commit]
 -   repo: https://github.com/pycqa/flake8
     # do flake8 last to avoid duplicate reports
     rev: 7.0.0

--- a/g2p/cli.py
+++ b/g2p/cli.py
@@ -177,14 +177,14 @@ def generate_mapping(  # noqa: C901
       g2p generate-mapping [--dummy|--ipa] IN_LANG [OUT_LANG]
 
       For specified IN_LANG, generate a mapping from IN_LANG-ipa to eng-ipa,
-      or from IN_LANG-ipa to a dummy minimalist phone inventory. This assumes
-      the mapping IN_LANG -> IN_LANG-ipa exists and creates a mapping from its
-      output inventory.
+    or from IN_LANG-ipa to a dummy minimalist phone inventory. This assumes
+    the mapping IN_LANG -> IN_LANG-ipa exists and creates a mapping from its
+    output inventory.
 
       To generate a mapping from IN_LANG-ipa to eng-ipa from a mapping
-      following a different patterns, e.g., from crl-equiv -> crl-ipa, specify
-      both IN_LANG (crl-equiv in this example) and OUT_LANG (crl-ipa in this
-      example).
+    following a different patterns, e.g., from crl-equiv -> crl-ipa, specify
+    both IN_LANG (crl-equiv in this example) and OUT_LANG (crl-ipa in this
+    example).
 
       \b
       Sample usage:
@@ -207,10 +207,10 @@ def generate_mapping(  # noqa: C901
       g2p generate-mapping --from FROM_L1:FROM_L2:... --to TO_L1:TO_L2:...
 
       Generate an IPA mapping from the union of FROM_L1-ipa, FROM-L2-ipa, etc to
-      the union of TO_L1-ipa, TO-L2-ipa, etc. One or more from/to language
-      code(s) can be specified in colon- or comma-separated lists. Note, by default
-      we use Panphon's weighted_feature_edit_distance, but you can change this with
-      the --distance argument
+    the union of TO_L1-ipa, TO-L2-ipa, etc. One or more from/to language
+    code(s) can be specified in colon- or comma-separated lists. Note, by default
+    we use Panphon's weighted_feature_edit_distance, but you can change this with
+    the --distance argument
 
     \b
       Sample usage:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
   "isort>=5.10.1",
   "mypy>=1; python_version < '3.8'",
   "mypy>=1.8.0; python_version >= '3.8'",
-  "pre-commit>=2.6.0",
+  "pre-commit>=3.2.0",
 ]
 # This one is a bit special and cannot depend on other features,
 # because if it depends on `g2p[api]` then we end up with


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Quiet the very verbose warnings that pre-commit gives due to our configuration being in an old format, and improve the presentation for `g2p generate-mapping -h` by formatting indented paragraphs the way markdown expects them.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

- make a commit with a pre-commit version 4 installed, and see the absence of warnings
- run `g2p generate-mapping -h` and see the fixed paragraphs formatted correctly, especially on small screens.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
