### PR TITLE
ci: fix test-studio to work with Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ api = [
 test = [
   "g2p[api]; python_version >= '3.8'",
   "coverage[toml]>=6.5",
-  "playwright>=1.26.1",
+  "playwright>=1.26.1,<1.46; python_version < '3.9'",
+  "playwright>=1.26.1; python_version >= '3.9'",
   "jsonschema>=4.17.3",
   "pep440>=0.1.2",
   "httpx",


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

the latest playwright breaks CI for Python 3.8, so hold it back before the version that breaks it.
