### PR TITLE
Dev.ej/stabilize test studio in ci

### DIFF
--- a/g2p/app.py
+++ b/g2p/app.py
@@ -285,7 +285,7 @@ async def change_table(sid, message) -> None:
         mappings: List[Mapping] = []
         for lang1, lang2 in zip(path[:-1], path[1:]):
             transducer = make_g2p(lang1, lang2, tokenize=False)
-            mappings.append(transducer.mapping)
+            mappings.append(transducer.mapping)  # type: ignore
         await SIO.emit(
             "table response",
             [

--- a/g2p/static/custom.js
+++ b/g2p/static/custom.js
@@ -529,6 +529,7 @@ function showSettings(index) {
 }
 
 tableSocket.on('table response', function(msg) {
+    $('#table-status').attr('state', 'processing response')
     // msg arg is list of {
     //  mappings: io pairs to be applied to hot table
     //  abbs: abbreviations to be included in abbreviations table
@@ -566,6 +567,7 @@ tableSocket.on('table response', function(msg) {
     }
     // convert
     convert()
+    $('#table-status').attr('state', 'loaded')
 })
 
 $('#input').on('keyup', function(event) {
@@ -607,6 +609,7 @@ $('#export-rules').click(function(event) {
     TABLES[index].getPlugin("exportFile").downloadFile("csv", { filename: "rules" });
 })
 $('#langselect').change(function() {
+    $('#table-status').attr('state', 'loading')
     var selected = $("#langselect option:selected").val();
     var in_lang = selected;
     var out_lang = selected;
@@ -630,6 +633,7 @@ $(document).ready(function() {
     });
 
     $("#input-langselect").on('change', function(event) {
+        $('#table-status').attr('state', 'loading input language')
         let in_lang = $("#input-langselect option:selected").val()
         $.ajax({
             url: "/api/v1/descendants/" + in_lang,
@@ -659,6 +663,7 @@ $(document).ready(function() {
     }
 
     $("#output-langselect").on('change', function(event) {
+        $('#table-status').attr('state', 'loading output language')
         changeTable()
     })
 

--- a/g2p/templates/index.html
+++ b/g2p/templates/index.html
@@ -86,6 +86,7 @@
                 <select id="output-langselect">
                     <option value="custom">Custom</option>
                 </select>
+                <span id="table-status" state="init"></span>
             </div>
             <div class='columns six mg-top'>
                 <h5>Settings</h5>

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -149,9 +149,13 @@ class StudioTest(IsolatedAsyncioTestCase):
                 for i, test in enumerate(
                     langs_to_test[block_size * block : block_size * (block + 1)]
                 ):
+                    test_in_lang = test[0].strip()
+                    test_out_lang = test[1].strip()
+                    test_input_text = test[2].strip()
+                    test_expected_output = test[3].strip()
                     LOGGER.info(
-                        f"{i+block*block_size} {datetime.now()} "
-                        f"{test[0]}->{test[1]} {test[2]} -> {test[3]}"
+                        f"{i + block * block_size} {datetime.now()} "
+                        f"{test_in_lang}->{test_out_lang} {test_input_text} -> {test_expected_output}"
                     )
                     for attempt in range(1, 4):
                         if attempt > 1:
@@ -163,13 +167,13 @@ class StudioTest(IsolatedAsyncioTestCase):
                         output_text = ""
 
                         # Select the input language
-                        await in_lang_selector.select_option(value=test[0])
+                        await in_lang_selector.select_option(value=test_in_lang)
                         # wait up to max_action_delay ms for input lang to be set
                         # and for mappings to be populated
                         loop_time = 0
                         while loop_time <= max_action_delay:
                             input_lang = await in_lang_selector.input_value()
-                            if input_lang.strip() == test[0].strip():
+                            if input_lang.strip() == test_in_lang:
                                 await page.wait_for_timeout(polling_period)
                                 break
                             await page.wait_for_timeout(polling_period)
@@ -181,13 +185,13 @@ class StudioTest(IsolatedAsyncioTestCase):
                             continue
 
                         # Select the output language
-                        await out_lang_selector.select_option(value=test[1])
+                        await out_lang_selector.select_option(value=test_out_lang)
                         # wait up to max_action_delay ms for output lang to be set
                         # and for mappings to be populated
                         loop_time = 0
                         while loop_time <= max_action_delay:
                             output_lang = await out_lang_selector.input_value()
-                            if output_lang.strip() == test[1].strip():
+                            if output_lang.strip() == test_out_lang:
                                 await page.wait_for_timeout(polling_period)
                                 break
                             await page.wait_for_timeout(polling_period)
@@ -200,14 +204,14 @@ class StudioTest(IsolatedAsyncioTestCase):
 
                         # Type fill input, then trigger rendering with keyup event
                         # optimization: make sure there is only 1 keyup event
-                        await input_el.fill(test[2] + " ")
+                        await input_el.fill(test_input_text + " ")
                         await input_el.press("Backspace")
 
                         loop_time = 0
                         # wait up to max_action_delay ms for output to be populated
                         while loop_time <= max_action_delay:
                             output_text = await output_el.input_value()
-                            if output_text.strip() == test[3].strip():
+                            if output_text.strip() == test_expected_output:
                                 break
                             await page.wait_for_timeout(polling_period)
                             loop_time += polling_period
@@ -218,28 +222,27 @@ class StudioTest(IsolatedAsyncioTestCase):
                             continue
 
                         # We're done trying once an attempt succeeds
-                        if output_text.strip() == test[3].strip():
+                        if output_text.strip() == test_expected_output:
                             break
 
                     # Check that output is correct after the first succesful attempt or
                     # after all the attempts have failed.
                     if not self.debug:
-                        self.assertEqual(output_text.strip(), test[3].strip())
+                        self.assertEqual(output_text.strip(), test_expected_output)
                         LOGGER.info(
-                            f"Successfully converted {test[2]} from {test[0]} to {test[1]}"
+                            f"Successfully converted {test_input_text} from {test_in_lang} to {test_out_lang}"
                         )
-                    elif output_text.strip() != test[3].strip():
+                    elif output_text.strip() != test_expected_output:
                         LOGGER.warning(
-                            f"test_langs.py: mapping error: {test[2]} from {test[0]} "
-                            f"to {test[1]} should be {test[3]}, got {output_text}"
+                            f"test_langs.py: mapping error: {test_input_text} from {test_in_lang} "
+                            f"to {test_out_lang} should be {test_expected_output}, got {output_text}"
                         )
-                        input_text = await input_el.input_value()
                         if error_count == 0:
-                            first_failed_test = [input_text, output_text]
+                            first_failed_test = [test_expected_output, output_text]
                         error_count += 1
                     else:
                         LOGGER.info(
-                            f"Successfully converted {test[2]} from {test[0]} to {test[1]}"
+                            f"Successfully converted {test_input_text} from {test_in_lang} to {test_out_lang}"
                         )
 
                 # Let the user know we're closing the browser (by exiting the p context

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -145,6 +145,7 @@ class StudioTest(IsolatedAsyncioTestCase):
                 output_el = page.locator("#output")
                 in_lang_selector = page.locator("#input-langselect")
                 out_lang_selector = page.locator("#output-langselect")
+                table_status_selector = page.locator("#table-status")
 
                 for i, test in enumerate(
                     langs_to_test[block_size * block : block_size * (block + 1)]
@@ -157,6 +158,7 @@ class StudioTest(IsolatedAsyncioTestCase):
                         f"{i + block * block_size} {datetime.now()} "
                         f"{test_in_lang}->{test_out_lang} {test_input_text} -> {test_expected_output}"
                     )
+                    timed_out_count = 0
                     for attempt in range(1, 4):
                         if attempt > 1:
                             LOGGER.info(f"Attempt #{attempt}")
@@ -167,16 +169,29 @@ class StudioTest(IsolatedAsyncioTestCase):
                         output_text = ""
 
                         # Select the input language
-                        await in_lang_selector.select_option(value=test_in_lang)
+                        # descendants_promise = page.wait
+                        async with page.expect_request(
+                            "**/descendants/" + test_in_lang
+                        ) as req_info:
+                            await in_lang_selector.select_option(value=test_in_lang)
+                        await req_info.value
                         # wait up to max_action_delay ms for input lang to be set
                         # and for mappings to be populated
                         loop_time = 0
                         while loop_time <= max_action_delay:
                             input_lang = await in_lang_selector.input_value()
-                            if input_lang.strip() == test_in_lang:
-                                await page.wait_for_timeout(polling_period)
+                            out_lang_available = await out_lang_selector.locator(
+                                f"option[value={test_out_lang}]",
+                            ).count()
+                            table_status = await table_status_selector.get_attribute(
+                                "state"
+                            )
+                            if (
+                                input_lang.strip() == test_in_lang
+                                and out_lang_available == 1
+                                and table_status == "loaded"
+                            ):
                                 break
-                            await page.wait_for_timeout(polling_period)
                             loop_time += polling_period
                         else:
                             LOGGER.warning(
@@ -184,23 +199,33 @@ class StudioTest(IsolatedAsyncioTestCase):
                             )
                             continue
 
-                        # Select the output language
-                        await out_lang_selector.select_option(value=test_out_lang)
-                        # wait up to max_action_delay ms for output lang to be set
-                        # and for mappings to be populated
-                        loop_time = 0
-                        while loop_time <= max_action_delay:
-                            output_lang = await out_lang_selector.input_value()
-                            if output_lang.strip() == test_out_lang:
-                                await page.wait_for_timeout(polling_period)
-                                break
+                        # In CI, selecting the output language is usually where things
+                        # time out, so we'll try 3 times before giving up.
+                        for _ in range(3):
+                            # Select the output language
+                            await out_lang_selector.select_option(value=test_out_lang)
+                            # wait up to max_action_delay ms for output lang to be set
+                            # and for mappings to be populated
                             await page.wait_for_timeout(polling_period)
-                            loop_time += polling_period
-                        else:
-                            LOGGER.warning(
-                                f"Reached timeout setting out_lang for {test}"
-                            )
-                            continue
+                            loop_time = 0
+                            while loop_time <= max_action_delay:
+                                output_lang = await out_lang_selector.input_value()
+                                table_status = (
+                                    await table_status_selector.get_attribute("state")
+                                )
+                                if (
+                                    output_lang.strip() == test_out_lang
+                                    and table_status == "loaded"
+                                ):
+                                    break
+                                await page.wait_for_timeout(polling_period)
+                                loop_time += polling_period
+                            else:
+                                LOGGER.warning(
+                                    f"Reached timeout setting out_lang for {test}"
+                                )
+                                continue  # try again
+                            break  # break out of both loops when the inner loop breaks
 
                         # Type fill input, then trigger rendering with keyup event
                         # optimization: make sure there is only 1 keyup event
@@ -219,12 +244,18 @@ class StudioTest(IsolatedAsyncioTestCase):
                             LOGGER.warning(
                                 f"Reached timeout setting input text for {test}"
                             )
+                            timed_out_count += 1
                             continue
 
                         # We're done trying once an attempt succeeds
                         if output_text.strip() == test_expected_output:
                             break
 
+                    if (
+                        timed_out_count == 3
+                        and output_text.strip() != test_expected_output
+                    ):  # pragma: no cover
+                        output_text = output_text + " (TIMED OUT)"
                     # Check that output is correct after the first succesful attempt or
                     # after all the attempts have failed.
                     if not self.debug:


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Stabilize testing in CI: test_studio is giving me erratic CI errors, in particular for the changes to kwk, and they are spurious.

This PR makes testing much more stable, and also updates our pre-commit configuration like we've done in ReadAlongs/Studio already.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

flaky CI

### Feedback sought? <!-- What should reviewers focus on in particular? -->

make sure the updated test_studio makes sense

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high, I need to merge this before #418

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

nothing but!

### How to test? <!-- Explain how reviewers should test this PR. -->

In one shell: `./run_studio.py`
In another: `g2p/tests/test_studio.py` and see all tests pass, which was the case before, but more importantly see CI pass reliably now.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
