### PR TITLE
build(deps): lock click<8.2.0 since it has breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "click>=8.0.4",
+    "click>=8.0.4,<8.2.0",
     "coloredlogs>=15.0.1",
     "openpyxl",
     "panphon>=0.19",


### PR DESCRIPTION
quick fix: click 8.2.0 has breaking changes we're not compatible with, most likely due to incompatibility with other dependencies, likely typer.

Look at the recent Actions runs of Matrix tests, that's where you'll see this patch making a difference, i.e., for Python >=3.10, since click 8.2.0 has dropped <3.10.