### PR TITLE
build: lock panphon <0.22 for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "openpyxl",
     "panphon>=0.19",
     "panphon<0.21; python_version<'3.9'",
+    "panphon<0.22; python_version<'3.10'",
     "panphon<0.21; platform_system=='Windows'",
     "pydantic>=2.4, <2.9",  # pydantic 2.9.0 changes our schema
     "pyyaml>=5.2",


### PR DESCRIPTION
Panphon 0.22.* has problems with Python 3.9, so let's block it.

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Block panphon <0.22 with Python 3.9 because it's not compatible.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

urgent

