### PR TITLE
fix(tests): use the default chromium channel for easier install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,10 @@ jobs:
           key: g2p-neural-${{ steps.weekno.outputs.WEEK_NUMBER }}
           path: ~/.cache/huggingface
       - run: uv pip install -e .[neural]
-      - run: coverage run g2p/tests/test_neural.py
+      - name: Run the neural unit tests
+        run: |
+          coverage run g2p/tests/test_neural.py |& tee neural-test.log
+          ! grep -i skip neural-test.log || ! echo "Error: neural test got skipped, something went wrong."
 
       - name: Run generate-mapping
         shell: bash
@@ -79,8 +82,8 @@ jobs:
         shell: bash
         run: |
           uv pip install 'pydantic<2.9'
-          coverage run -m unittest -v g2p.tests.test_cli.CliTest.test_update_schema_with_pydantic_lt29 |& tee schema-test.txt
-          ! grep -i skip schema-test.txt || ! echo "Error: Schema update test got skipped, something went wrong."
+          coverage run -m unittest -v g2p.tests.test_cli.CliTest.test_update_schema_with_pydantic_lt29 |& tee schema-test.log
+          ! grep -i skip schema-test.log || ! echo "Error: Schema update test got skipped, something went wrong."
 
       - name: Post test analyses
         run: |

--- a/g2p/tests/test_cli.py
+++ b/g2p/tests/test_cli.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from unittest import SkipTest, TestCase, main, mock
+from unittest import TestCase, main, mock
 
 import jsonschema
 import pydantic
@@ -134,22 +134,23 @@ class CliTest(TestCase):
             result = self.runner.invoke(update, ["-i", bad_langs_dir, "-o", tmpdir])
             self.assertEqual(result.exit_code, 0)
 
-    def test_wont_update_schema_with_pydantic_ge29(self):
-        """Make sure schema update does nothing when Pydantic>=2.9"""
-        pydantic_major, pydantic_minor, _ = pydantic.VERSION.split(".", 3)
-        if (int(pydantic_major), int(pydantic_minor)) < (2, 9):
-            raise SkipTest("This test is only meaningful with pydantic>=2.9")
-
-        result = self.runner.invoke(update_schema)
-        self.assertEqual(result.exit_code, 0)
-        self.assertIn("Please use Pydantic", result.output)
-
     def test_update_schema_with_pydantic_lt29(self):
         """Make sure schema update works (requires Pydantic<2.9)"""
+
         # Skip this test if the currently installed pydantic version is >= 2.9
         pydantic_major, pydantic_minor, _ = pydantic.VERSION.split(".", 3)
         if (int(pydantic_major), int(pydantic_minor)) >= (2, 9):
-            raise SkipTest("This test is only meaningful with pydantic<2.9")
+            # With Pydantic>=2.9, we cannot update the schemas, instead we
+            # expect an error message telling us to use an older version
+            result = self.runner.invoke(update_schema)
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("Please use Pydantic", result.output)
+            LOGGER.info(
+                "Skipping the rest of the schema update test since we have pydantic>=2.9"
+            )
+            return  # skip the rest of the test
+
+        # The rest of this test can assume pydantic<2.9 is installed.
 
         # It's an error for the currently saved schema to be out of date
         result = self.runner.invoke(update_schema)

--- a/g2p/tests/test_neural.py
+++ b/g2p/tests/test_neural.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
 import sys
-from unittest import TestCase, main, SkipTest
+from unittest import SkipTest, TestCase, main
 
 from g2p import make_g2p
 from g2p.log import LOGGER
+from g2p.mappings.utils import has_neural_support
 from g2p.tests.public.data import load_neural_test_data
 
 
@@ -20,6 +21,8 @@ class NeuralLangTest(TestCase):
     def test_io(self):
         if sys.version_info < (3, 9):
             raise SkipTest("neural g2p requires python >= 3.9")
+        if not has_neural_support():
+            raise SkipTest("neural not installed; skipping neural tests")
         langs_to_test = load_neural_test_data()
 
         # go through each language declared in the test case set up

--- a/g2p/tests/test_studio.py
+++ b/g2p/tests/test_studio.py
@@ -17,7 +17,7 @@ from random import sample
 from unittest import IsolatedAsyncioTestCase, main
 
 import socketio  # type: ignore
-from playwright.async_api import async_playwright, expect  # type: ignore
+from playwright.async_api import Error, async_playwright, expect  # type: ignore
 
 from g2p.log import LOGGER
 from g2p.tests.public.data import load_public_test_data
@@ -39,7 +39,12 @@ class StudioTest(IsolatedAsyncioTestCase):
 
     async def test_sanity(self):
         async with async_playwright() as p:
-            browser = await p.chromium.launch(channel="chrome", headless=True)
+            try:  # pragma: no cover
+                browser = await p.chromium.launch(channel="chrome", headless=True)
+                LOGGER.info("Running playwright with chrome channel")
+            except Error:  # pragma: no cover
+                browser = await p.chromium.launch(headless=True)
+                LOGGER.info("Running playwright with default chromium channel")
             page = await browser.new_page()
             await page.goto(f"http://127.0.0.1:{self.port}/docs")
             await page.wait_for_timeout(self.timeout_delay)
@@ -65,7 +70,12 @@ class StudioTest(IsolatedAsyncioTestCase):
 
     async def test_switch_langs(self):
         async with async_playwright() as p:
-            browser = await p.chromium.launch(channel="chrome", headless=True)
+            try:  # pragma: no cover
+                browser = await p.chromium.launch(channel="chrome", headless=True)
+                LOGGER.info("Running playwright with chrome channel")
+            except Error:  # pragma: no cover
+                browser = await p.chromium.launch(headless=True)
+                LOGGER.info("Running playwright with default chromium channel")
             page = await browser.new_page()
             await page.goto(f"http://127.0.0.1:{self.port}")
             await page.wait_for_timeout(self.timeout_delay)
@@ -155,7 +165,12 @@ class StudioTest(IsolatedAsyncioTestCase):
             LOGGER.info("Lauching async_playwright")
             async with async_playwright() as p:
                 LOGGER.info(("L" if block == 0 else "Rel") + "aunching browser")
-                browser = await p.chromium.launch(channel="chrome", headless=True)
+                try:  # pragma: no cover
+                    browser = await p.chromium.launch(channel="chrome", headless=True)
+                    LOGGER.info("Running playwright with chrome channel")
+                except Error:  # pragma: no cover
+                    browser = await p.chromium.launch(headless=True)
+                    LOGGER.info("Running playwright with default chromium channel")
                 LOGGER.info("Loading page")
                 page = await browser.new_page()
                 await page.goto(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ test = [
   "playwright>=1.26.1; python_version >= '3.9'",
   "jsonschema>=4.17.3",
   "pep440>=0.1.2",
+  "pytest",
   "httpx",
   # Kind of bogus that we need both httpx and aiohttp, but socketio
   # wants this


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Use the default chromium channel from playwright instead of specifying the chrome channel. The latter breaks on my Ubuntu machine, while the former seems to work everywhere.

In particular, `playwright install chromium` can be done as a regular user, but `playwright install chrome` requires root access on Ubuntu, so the latter is easier to accomplish.

### How to test? <!-- Explain how reviewers should test this PR. -->

@marctessier I have tested this on Windows and Linux, can you test it on Linux?

```
./run_studio.py &
g2p/tests/test_studio.py
```

should take about 30s to successfully run this suite.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high for Windows and Linux, hopeful for Mac too.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
